### PR TITLE
enable chunkerfunc for only position parameterizations

### DIFF
--- a/chunkie/checkcurveparam.m
+++ b/chunkie/checkcurveparam.m
@@ -1,4 +1,4 @@
-function dim = checkcurveparam(fcurve,ta)
+function dim = checkcurveparam(fcurve,ta,nout)
 %CHECKCURVEPARAM check if a curve parameterization is correctly formatted 
 % and return the dimension of the curve.
 %
@@ -8,11 +8,16 @@ function dim = checkcurveparam(fcurve,ta)
 %
 % Input: 
 %   fcurve - function handle of the form
-%               [r,d,d2] = fcurve(t)
-%            where r, d, d2 are size [dim,size(t)] arrays describing
-%            position, first derivative, and second derivative of a curve
-%            in dim dimensions parameterized by t.
+%               r = fcurve(t);
+%            where r is a size [dim,size(t)] arrays describing
+%            the position of a curve in dim dimensions parameterized by t.
+%
+%            optionally, the function can be of the form 
+%               [r,d] = fcurve(t);  or [r,d,d2] = fcurve(t);
+%            where d is the first derivative of r with respect to t and 
+%            d2 is the second derivative. 
 %   ta - sample point t in parameterization to test
+%   nout - number of outputs of fcurve
 %
 % Output:
 %   dim - the dimension of the curve
@@ -21,7 +26,10 @@ function dim = checkcurveparam(fcurve,ta)
 %   dim = checkcurveparam(@(t) starfish(t),0.0);
 
 
-nout = 3;
+if nargin < 3
+    nout = 3;
+end
+
 out = cell(nout,1);
 [out{:}] = fcurve(ta);
 

--- a/chunkie/chunkerfunc.m
+++ b/chunkie/chunkerfunc.m
@@ -5,10 +5,15 @@ function chnkr = chunkerfunc(fcurve,cparams,pref)
 %
 % Input: 
 %   fcurve - function handle of the form
-%               [r,d,d2] = fcurve(t)
-%            where r, d, d2 are size [dim,size(t)] arrays describing
-%            position, first derivative, and second derivative of a curve
-%            in dim dimensions parameterized by t.
+%               r = fcurve(t);
+%            where r is a size [dim,size(t)] arrays describing
+%            the position of a curve in dim dimensions parameterized by t.
+%
+%            optionally, the function can be of the form 
+%               [r,d] = fcurve(t);  or [r,d,d2] = fcurve(t);
+%            where d is the first derivative of r with respect to t and 
+%            d2 is the second derivative. in some situations, this will
+%            improve the convergence order. 
 %
 % Optional input:
 %	cparams - curve parameters structure (defaults)
@@ -63,6 +68,7 @@ ta = 0.0; tb = 2*pi; ifclosed=true;
 chsmall = Inf; nover = 0;
 eps = 1.0e-6;
 lvlr = 'a'; maxchunklen = Inf; lvlrfac = 2.0;
+nout = 1;
 
 if isfield(cparams,'ta')
     ta = cparams.ta;
@@ -92,14 +98,25 @@ if isfield(cparams,'maxchunklen')
     maxchunklen = cparams.maxchunklen;
 end
 
+% discover number of outputs
+try         
+    [r,d,d2] = fcurve(t);
+    nout = 3;
+catch
+    try 
+        [r,d] = fcurve(ta);
+        nout = 2;
+    catch
+        nout = 1;
+    end
+end
+
 k = pref.k;
 nchmax = pref.nchmax; 
  
-dim = checkcurveparam(fcurve,ta);
+dim = checkcurveparam(fcurve,ta,nout);
 pref.dim = dim;
-nout = 3;
-out = cell(nout,1);
-
+out = cell(3,1);
 
 ifprocess = zeros(nchmax,1);
 
@@ -108,13 +125,13 @@ ifprocess = zeros(nchmax,1);
 
 k2 = 2*k;
 [xs,ws,us,vs] = lege.exps(k);
-[xs2,ws2,u2] = lege.exps(k2);   
+dermat = (vs*[lege.derpol(us); zeros(1,k)]).';
+[xs2,ws2,u2,v2] = lege.exps(k2);   
+dermat2 = (v2*[lege.derpol(u2); zeros(1,k2)]).';
 
 xs2p = ((1:k2)-1)/(k2-1)*2-1;
 [polvals,~] = lege.pols(xs2p,k-1);
 interp_xs = reshape(polvals,[k,k2]).'*us; 
-
-
 
 %       . . . start chunking
 
@@ -153,8 +170,13 @@ for ijk = 1:maxiter_res
             b=ab(2,ich);
            
             ts = a + (b-a)*(xs2+1)/2.0;
-            [r,d,d2] = fcurve(ts);
-
+            [out{1:nout}] = fcurve(ts);
+            for j = nout+1:3
+                out{j} = out{j-1}*dermat2*(2/(b-a));
+            end
+            r = out{1};
+            d = out{2};
+            d2 = out{3};
             zd = d(1,:)+1i*d(2,:);
             vd = abs(zd);
             zdd= d2(1,:)+1i*d2(2,:);
@@ -168,6 +190,9 @@ for ijk = 1:maxiter_res
             err1 = sqrt(errs/errs0/k);
             
             resol_speed_test = err1>eps;
+            if nout < 2
+                resol_speed_test = err1>eps*k;
+            end
             
             xmax = max(xmax,max(r(1,:)));
             ymax = max(ymax,max(r(2,:)));
@@ -278,7 +303,7 @@ if or(strcmpi(lvlr,'a'),strcmpi(lvlr,'t'))
             b=ab(2,i);
             
             if strcmpi(lvlr,'a')
-                rlself = chunklength(fcurve,a,b,xs,ws);
+                rlself = chunklength(fcurve,a,b,xs,ws,nout,dermat);
 
                 rl1=rlself;
                 rl2=rlself;
@@ -286,12 +311,12 @@ if or(strcmpi(lvlr,'a'),strcmpi(lvlr,'t'))
                 if (i1 > 0)
                     a1=ab(1,i1);
                     b1=ab(2,i1);
-                    rl1 = chunklength(fcurve,a1,b1,xs,ws);
+                    rl1 = chunklength(fcurve,a1,b1,xs,ws,nout,dermat);
                 end
                 if (i2 > 0)
                     a2=ab(1,i2);
                     b2=ab(2,i2);
-                    rl2 = chunklength(fcurve,a2,b2,xs,ws);
+                    rl2 = chunklength(fcurve,a2,b2,xs,ws,nout,dermat);
                 end
             else
                 
@@ -367,36 +392,64 @@ if (nover > 0)
         for i = 1:nchold
             a=ab(1,i);
             b=ab(2,i);
-		   %       find ab2 using newton such that 
-		   %       len(a,ab2)=len(ab2,b)=half the chunk length
-            rl = chunklength(fcurve,a,b,xs,ws);
+
+              % use dekker's method (hybrid secant/bisection)
+           
+            rl = chunklength(fcurve,a,b,xs,ws,nout,dermat);
             rlhalf=rl/2;
-            thresh=1.0d-8;
-            ifnewt=0;
-            ab0=(a+b)/2;
-            for iter = 1:1000
-
-                [rl1] = chunklength(fcurve,a,ab0,xs,ws);
+            
+            fak = -rlhalf;
+            fbk = rlhalf;
+            
+            thresh=eps*10*rad_curr;
+            
+            ak = a;
+            bk = b;
+            
+            fbkm1 = fbk;
+            bkm1 = bk;
+            
+            for iter = 1:200
+                m = (ak+bk)/2;
+                s = m;
+                if fbkm1 ~= fbk
+                    s = bk - (bk-bkm1)*fbk/(fbk-fbkm1);
+                end
                 
-                [out{:}] = fcurve(ab0);
-                dsdt = sqrt(sum((abs(out{2})).^2));
-                ab1=ab0-(rl1-rlhalf)/dsdt;
-
-                err=rl1-rlhalf;
-                if (abs(err) < thresh)
-                    ifnewt=ifnewt+1;
+                if (s-m)*(s-bk) >= 0
+                    s = m;
                 end
 
-                if (ifnewt == 3)
-                    break;
+                % store last iterate values
+                bkm1 = bk;
+                fbkm1 = fbk;
+
+                bk = s;
+                fbk = chunklength(fcurve,a,bk,xs,ws,nout,dermat)-rlhalf;
+                
+                % update bracket
+                if fak*fbk >= 0
+                    ak = bkm1;
+                    fak = fbkm1;
                 end
-                ab0=ab1;
+                
+                % check if b is still the best guess
+                if abs(fbk) > abs(fak)
+                    tmp = bk;
+                    bk = ak;
+                    ak = tmp;
+                    tmp = fbk;
+                    fbk = fak;
+                    fak = tmp;
+                end                    
+                
+                if (abs(fbk) < thresh)
+                    break
+                    disp(iter)
+                end
             end
 	 
-            if (ifnewt < 3) 
-                error('newton failed in chunkerfunc');
-            end
-            ab2=ab1;
+            ab2=bk;
 
             i1=adjs(1,i);
             i2=adjs(2,i);
@@ -436,7 +489,10 @@ for i = 1:nch
     b=ab(2,i);
     
     ts = a + (b-a)*(xs+1)/2;
-    [out{:}] = fcurve(ts);
+    [out{1:nout}] = fcurve(ts);
+    for j = nout+1:3
+        out{j} = out{j-1}*dermat*(2/(b-a));
+    end
     chnkr.rstor(:,:,i) = reshape(out{1},dim,k);
     chnkr.dstor(:,:,i) = reshape(out{2},dim,k);
     chnkr.d2stor(:,:,i) = reshape(out{3},dim,k);
@@ -446,17 +502,19 @@ end
 chnkr.adjstor(:,1:nch) = adjs(:,1:nch);
 
 % update normals
-chnkr.n(:,:,1:nch) = normals(chnkr);
+chnkr.nstor(:,:,1:nch) = normals(chnkr);
 
 end
 
 
-function [len] = chunklength(fcurve,a,b,xs,ws)
+function [len] = chunklength(fcurve,a,b,xs,ws,nout,dermat)
     
-    nout = 3;
-    out = cell(nout,1);
+    out = cell(3,1);
     ts = a+(b-a)*(xs+1)/2;
-    [out{:}] = fcurve(ts);
+    [out{1:nout}] = fcurve(ts);
+    for j = nout+1:3
+        out{j} = out{j-1}*dermat*(2/(b-a));
+    end
     dsdt = sqrt(sum(abs(out{2}).^2,1));
     len = dot(dsdt,ws)*(b-a)/2;
  end

--- a/chunkie/chunkerfuncuni.m
+++ b/chunkie/chunkerfuncuni.m
@@ -5,10 +5,15 @@ function chnkr = chunkerfuncuni(fcurve,nch,cparams,pref)
 %
 % Input: 
 %   fcurve - function handle of the form
-%               [r,d,d2] = fcurve(t)
-%            where r, d, d2 are size [dim,size(t)] arrays describing
-%            position, first derivative, and second derivative of a curve
-%            in dim dimensions parameterized by t.
+%               r = fcurve(t);
+%            where r is a size [dim,size(t)] arrays describing
+%            the position of a curve in dim dimensions parameterized by t.
+%
+%            optionally, the function can be of the form 
+%               [r,d] = fcurve(t);  or [r,d,d2] = fcurve(t);
+%            where d is the first derivative of r with respect to t and 
+%            d2 is the second derivative. in some situations, this will
+%            improve the convergence order. 
 %
 % Optional input:
 %   nch - number of chunks to use (16)
@@ -46,9 +51,6 @@ end
 
 
 ta = 0.0; tb = 2*pi; ifclosed=true;
-chsmall = Inf; nover = 0;
-eps = 1.0e-6;
-lvlr = 'a'; maxchunklen = Inf; lvlrfac = 2.0;
 
 if isfield(cparams,'ta')
     ta = cparams.ta;
@@ -60,16 +62,30 @@ if isfield(cparams,'ifclosed')
     ifclosed = cparams.ifclosed;
 end	 
 
+% discover number of outputs
+try         
+    [r,d,d2] = fcurve(t);
+    nout = 3;
+catch
+    try 
+        [r,d] = fcurve(ta);
+        nout = 2;
+    catch
+        nout = 1;
+    end
+end
+
 ts = linspace(ta,tb,nch+1);
 
 k = pref.k;
  
-dim = checkcurveparam(fcurve,ta);
+dim = checkcurveparam(fcurve,ta,nout);
 pref.dim = dim;
-nout = 3;
-out = cell(nout,1);
+out = cell(3,1);
 
-[xs,ws] = lege.exps(k);
+[xs,~,us,vs] = lege.exps(k);
+dermat = (vs*[lege.derpol(us); zeros(1,k)]).';
+
 
 %       . . . start chunking
 
@@ -103,16 +119,19 @@ for i = 1:nch
     b=ab(2,i);
     
     ts = a + (b-a)*(xs+1)/2;
-    [out{:}] = fcurve(ts);
-    chnkr.r(:,:,i) = reshape(out{1},dim,k);
-    chnkr.d(:,:,i) = reshape(out{2},dim,k);
-    chnkr.d2(:,:,i) = reshape(out{3},dim,k);
-    chnkr.h(i) = (b-a)/2;
+    [out{1:nout}] = fcurve(ts);
+    for j = nout+1:3
+        out{j} = out{j-1}*dermat*(2/(b-a));
+    end
+    chnkr.rstor(:,:,i) = reshape(out{1},dim,k);
+    chnkr.dstor(:,:,i) = reshape(out{2},dim,k);
+    chnkr.d2stor(:,:,i) = reshape(out{3},dim,k);
+    chnkr.hstor(i) = (b-a)/2;
 end
 
-chnkr.adj = adjs(:,1:nch);
+chnkr.adjstor(:,1:nch) = adjs(:,1:nch);
 
 % Set normals
-chnkr.n = normals(chnkr);
+chnkr.nstor(:,:,1:nch) = normals(chnkr);
 
 end

--- a/devtools/test/chunkerfuncTest.m
+++ b/devtools/test/chunkerfuncTest.m
@@ -22,6 +22,17 @@ assert(info.ier == 0,'adjacency issues after chunk build starfish');
 %
 
 fprintf('%5.2e seconds to chunk starfish with %d chunks\n',t1,chnkr.nch);
+
+cparams.nout = 3;
+start = tic; chnkr = chunkerfunc(@(t) starfish(t,narms,amp),cparams,pref); 
+t1 = toc(start);
+
+[~,~,info] = sortinfo(chnkr);
+assert(info.ier == 0,'adjacency issues after chunk build starfish');
+
+%
+
+fprintf('%5.2e seconds to chunk starfish with %d chunks\n',t1,chnkr.nch);
 % 
 % figure(1)
 % clf
@@ -58,9 +69,10 @@ assert(info.ier == 0,'adjacency issues after chunker reversal');
 
 % chunk up circle and test area
 
-modes = 5*rand(); ctr = [1.0;-0.5];
+r = 5*rand(); ctr = [1.0;-0.5];
 
-start = tic; chnkr = chunkerfunc(@(t) chnk.curves.bymode(t,modes,ctr),cparams); 
+circfun = @(t) ctr + r*[cos(t(:).');sin(t(:).')];
+start = tic; chnkr = chunkerfunc(circfun,cparams); 
 t1 = toc(start);
 
 fprintf('%5.2e seconds to chunk circle domain with %d chunks\n', ...
@@ -70,7 +82,7 @@ fprintf('%5.2e seconds to chunk circle domain with %d chunks\n', ...
 assert(info.ier == 0,'adjacency issues after chunk build circle');
 
 a = area(chnkr);
-assert(abs(a - pi*modes^2) < 1e-12,'area wrong for circle domain')
+assert(abs(a - pi*r^2) < 1e-12,'area wrong for circle domain')
 
 
 % subplot(1,3,3)

--- a/devtools/test/chunkerfuncuniTest.m
+++ b/devtools/test/chunkerfuncuniTest.m
@@ -6,13 +6,12 @@
 
 clearvars; close all;
 addpaths_loc();
-cparams = [];
-cparams.npan = 16;
-pref = []; 
-pref.k = 16;
+
+nch = 10;
+
 narms = 3;
 amp = 0.5;
-start = tic; chnkr = chnk.funcuni(@(t) starfish(t,narms,amp),cparams,pref); 
+start = tic; chnkr = chunkerfuncuni(@(t) starfish(t,narms,amp),nch); 
 t1 = toc(start);
 
 %
@@ -31,7 +30,7 @@ axis equal
 
 modes = randn(11,1); modes(1) = 1.1*sum(abs(modes(2:end))); ctr = [1.0;-0.5];
 
-start = tic; chnkr = chnk.funcuni(@(t) chnk.curves.bymode(t,modes,ctr),cparams); 
+start = tic; chnkr = chunkerfuncuni(@(t) chnk.curves.bymode(t,modes,ctr),nch);
 t1 = toc(start);
 
 fprintf('%5.2e seconds to chunk random mode domain with %d chunks\n', ...
@@ -48,9 +47,11 @@ axis equal
 
 % chunk up circle and test area
 
-modes = 5*rand(); ctr = [1.0;-0.5];
+r = 5*rand(); ctr = [1.0;-0.5];
 
-start = tic; chnkr = chnk.funcuni(@(t) chnk.curves.bymode(t,modes,ctr),cparams); 
+circfun = @(t) ctr + r*[cos(t(:).');sin(t(:).')];
+
+start = tic; chnkr = chunkerfuncuni(circfun,nch); 
 t1 = toc(start);
 
 fprintf('%5.2e seconds to chunk circle domain with %d chunks\n', ...
@@ -60,6 +61,6 @@ fprintf('%5.2e seconds to chunk circle domain with %d chunks\n', ...
 assert(info.ier == 0,'adjacency issues after chunk build circle');
 
 a = area(chnkr);
-assert(abs(a - pi*modes^2) < 1e-12,'area wrong for circle domain')
+assert(abs(a - pi*r^2) < 1e-12,'area wrong for circle domain')
 
 


### PR DESCRIPTION
- note: if only position is provided, the speed (ds/dt) resolution criterion is modified by a factor of k
- chnk.rcip.chunkerfunclocal is left alone
- closes issue #20 