### PR TITLE
Demo and test fixes

### DIFF
--- a/chunkie/+chnk/+helm2d/fmm.m
+++ b/chunkie/+chnk/+helm2d/fmm.m
@@ -75,21 +75,21 @@ function [pot,varargout] = fmm(eps,zk,srcinfo,targ,type,sigma,pgt,varargin)
    pot = U.pottarg.';
    if strcmpi(type,'sprime') || strcmpi(type,'dprime')
      if isfield(targ,'n')
-         pot = (U.gradtarg(1.:).*targ.n(1,:) + U.gradtarg(2,:).*targ.n(2,:)).'; 
+         pot = (U.gradtarg(1,:).*targ.n(1,:) + U.gradtarg(2,:).*targ.n(2,:)).'; 
      else
         error('HELM2D.FMM: targets require normal info when evaluating',...
                  'sprime, or dprime'); 
      end
    end
    if(pgt>=2) 
-       if strcmpi(type, 'sprime' || strcmpi(type,'dprime') || strcmpi(type,'stau')
+       if strcmpi(type, 'sprime') || strcmpi(type,'dprime') || strcmpi(type,'stau')
            warning("Gradients not supported for sprime, dprime, stau")
        else
            varargout{1} = U.gradtarg;
        end
    end
    if(pgt==3)
-       if strcmpi(type, 'sprime' || strcmpi(type,'dprime') || strcmpi(type,'stau')
+       if strcmpi(type, 'sprime') || strcmpi(type,'dprime') || strcmpi(type,'stau')
            warning("Hessians not supported for sprime, dprime, stau")
        else
            varargout{2} = U.hesstarg;

--- a/chunkie/+chnk/+helm2d/fmm.m
+++ b/chunkie/+chnk/+helm2d/fmm.m
@@ -32,12 +32,16 @@ function [pot,varargout] = fmm(eps,zk,srcinfo,targ,type,sigma,pgt,varargin)
 %   type - string, determines kernel type
 %                type == 'd', double layer kernel D
 %                type == 's', single layer kernel S
-%                type == 'c', combined layer kernel D + i eta S
-%   varargin{1} - eta in the combined layer formula, otherwise
+%                type == 'c', combined layer kernel coefs(1)*D + coefs(2)*S
+%                type = 'sprime' normal derivative of single layer, 
+%                   note that targinfo must contain targ.n
+%                type = 'dprime' normal derivative of double layer,
+%                   note that targinfo must contain targ.n
+%   varargin{1} - coef in the combined layer formula, otherwise
 %                does nothing
 %
 % Output:
-%   pot - potential corresponding to the kernel at the target locations
+%   pot - potential/neumann data corresponding to the kernel at the target locations
 %
 % Optional output
 %   grad  - gradient at target locations
@@ -52,10 +56,10 @@ function [pot,varargout] = fmm(eps,zk,srcinfo,targ,type,sigma,pgt,varargin)
     end
    srcuse = [];
    srcuse.sources = srcinfo.r(1:2,:);
-   if strcmpi(type,'s')
+   if strcmpi(type,'s') || strcmpi(type,'sprime')
       srcuse.charges = sigma(:).';
    end
-   if strcmpi(type,'d')
+   if strcmpi(type,'d') || strcmpi(type, 'dprime')
       srcuse.dipstr = sigma(:).';
       srcuse.dipvec = srcinfo.n(1:2,:);
    end
@@ -65,13 +69,30 @@ function [pot,varargout] = fmm(eps,zk,srcinfo,targ,type,sigma,pgt,varargin)
      srcuse.dipvec = srcinfo.n(1:2,:);
      srcuse.charges = coefs(2)*sigma(:).';
    end
+
    pg = 0;
    U = hfmm2d(eps,zk,srcuse,pg,targuse,pgt);
    pot = U.pottarg.';
-   if(pgt>=2) 
-       varargout{1} = U.gradtarg; 
+   if strcmpi(type,'sprime') || strcmpi(type,'dprime')
+     if isfield(targ,'n')
+         pot = (U.gradtarg(1.:).*targ.n(1,:) + U.gradtarg(2,:).*targ.n(2,:)).'; 
+     else
+        error('HELM2D.FMM: targets require normal info when evaluating',...
+                 'sprime, or dprime'); 
+     end
    end
-   if(pgt==3) 
-       varargout{2} = U.hesstarg; 
+   if(pgt>=2) 
+       if strcmpi(type, 'sprime' || strcmpi(type,'dprime') || strcmpi(type,'stau')
+           warning("Gradients not supported for sprime, dprime, stau")
+       else
+           varargout{1} = U.gradtarg;
+       end
+   end
+   if(pgt==3)
+       if strcmpi(type, 'sprime' || strcmpi(type,'dprime') || strcmpi(type,'stau')
+           warning("Hessians not supported for sprime, dprime, stau")
+       else
+           varargout{2} = U.hesstarg;
+       end
    end
 end

--- a/chunkie/+chnk/+helm2d/kern.m
+++ b/chunkie/+chnk/+helm2d/kern.m
@@ -14,6 +14,7 @@ function submat= kern(zk,srcinfo,targinfo,type,varargin)
 % D(x,y) = \nabla_{n_y} G(x,y)
 % S(x,y) = G(x,y)
 % S'(x,y) = \nabla_{n_x} G(x,y)
+% D'(x,y) = \nabla_{n_x} \nabla_{n_y} G(x,y)
 %
 % Input:
 %   zk - complex number, Helmholtz wave number
@@ -32,9 +33,28 @@ function submat= kern(zk,srcinfo,targinfo,type,varargin)
 %                type == 's', single layer kernel S
 %                type == 'sprime', normal derivative of single
 %                      layer S'
-%                type == 'c', combined layer kernel alpha D + beta S
-%   varargin{1} - length 2 array [alpha,beta] in the combined layer 
-%                 formula, otherwise does nothing
+%                type == 'dprime', normal derivative of double layer D'
+%                type == 'c', combined layer kernel coef(1) D + coef(2) S
+%                type == 'stau', tangential derivative of single layer
+%                type == 'all', returns all four layer potentials, 
+%                       [coef(1,1)*D coef(1,2)*S; coef(2,1)*D' coef(2,2)*S']
+%                type == 'c2trans' returns the combined field, and the 
+%                          normal derivative of the combined field
+%                        [coef(1)*D + coef(2)*S; coef(1)*D' + coef(2)*S']
+%                type == 'trans_rep' returns the potential corresponding
+%                           to the transmission representation
+%                        [coef(1)*D coef(2)*S]
+%                type == 'trans_rep_prime' returns the normal derivative
+%                          corresponding to the transmission representation
+%                        [coef(1)*D' coef(2)*S']
+%                type == 'trans_rep_grad' returns the gradient corresponding
+%                         to the transmission representation
+%                        [coef(1)*d_x D coef(2)*d_x S;
+%                         coef(1)*d_y D coef(2)*d_y S]
+%
+%   varargin{1} - coef: length 2 array in the combined layer 
+%                 formula, 2x2 matrix for all kernels
+%                 otherwise does nothing
 %
 % Output:
 %   submat - the evaluation of the selected kernel for the
@@ -50,6 +70,7 @@ targ = targinfo.r;
 [~,ns] = size(src);
 [~,nt] = size(targ);
 
+% double layer
 if strcmpi(type,'d')
   srcnorm = srcinfo.n;
   [~,grad] = chnk.helm2d.green(zk,src,targ);
@@ -58,6 +79,7 @@ if strcmpi(type,'d')
   submat = -(grad(:,:,1).*nx + grad(:,:,2).*ny);
 end
 
+% normal derivative of single layer
 if strcmpi(type,'sprime')
   targnorm = targinfo.n;
   [~,grad] = chnk.helm2d.green(zk,src,targ);
@@ -67,19 +89,23 @@ if strcmpi(type,'sprime')
   submat = (grad(:,:,1).*nx + grad(:,:,2).*ny);
 end
 
-if strcmpi(type,'sdtau')
+
+% Tangential derivative of single layer
+if strcmpi(type,'stau')
   targtan = targinfo.d;
   [~,grad] = chnk.helm2d.green(zk,src,targ);
   dx = repmat((targtan(1,:)).',1,ns);
   dy = repmat((targtan(2,:)).',1,ns);
-  dn = sqrt(dx.*dx+dy.*dy);
-  submat = (grad(:,:,1).*dx./dn + grad(:,:,2).*dy)./dn;
+  ds = sqrt(dx.*dx+dy.*dy);
+  submat = (grad(:,:,1).*dx + grad(:,:,2).*dy)./ds;
 end
 
+% single layer
 if strcmpi(type,'s')
   submat = chnk.helm2d.green(zk,src,targ);
 end
 
+% normal derivative of double layer
 if strcmpi(type,'dprime')
   targnorm = targinfo.n;
   srcnorm = srcinfo.n;
@@ -92,9 +118,11 @@ if strcmpi(type,'dprime')
       + hess(:,:,3).*nysrc.*nytarg);
 end
 
+% Combined field 
 if strcmpi(type,'c')
   srcnorm = srcinfo.n;
-  coef = varargin{1};
+  coef = ones(2,1);
+  if(nargin == 5); coef = varargin{1}; end
   [submats,grad] = chnk.helm2d.green(zk,src,targ);
   nx = repmat(srcnorm(1,:),nt,1);
   ny = repmat(srcnorm(2,:),nt,1);
@@ -102,33 +130,89 @@ if strcmpi(type,'c')
   submat = coef(1)*submatd + coef(2)*submats;
 end
 
-if strcmpi(type,'all')
-  %targnorm = chnk.normal2d(targinfo);
-  %srcnorm = chnk.normal2d(srcinfo);
-  % added by Shidong Jiang to avoid O(N^2) calculation of normals
+% normal derivative of combined field
+if strcmpi(type,'cprime')
+  coef = ones(2,1);
+  if(nargin == 5); coef = varargin{1}; end;
   targnorm = targinfo.n;
   srcnorm = srcinfo.n;
-  cc = varargin{1};
   
-  submat = zeros(2*nt,2*ns);
-  % S
+  submat = zeros(nt,ns);
+
+  % Get gradient and hessian info
   [submats,grad,hess] = chnk.helm2d.green(zk,src,targ);
-  %[submat(1:2:2*nt,2:2:2*ns),grad,hess] = chnk.helm2d.green(zk,src,targ);
 
   nxsrc = repmat(srcnorm(1,:),nt,1);
   nysrc = repmat(srcnorm(2,:),nt,1);
   nxtarg = repmat((targnorm(1,:)).',1,ns);
   nytarg = repmat((targnorm(2,:)).',1,ns);
+
   % D'
-  %submat(2:2:2*nt,1:2:2*ns) = -(hess(:,:,1).*nxsrc.*nxtarg ... 
   submatdp = -(hess(:,:,1).*nxsrc.*nxtarg ...
       + hess(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
       + hess(:,:,3).*nysrc.*nytarg);
   % S'
-%  submat(2:2:2*nt,2:2:2*ns) = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
+  submatsp = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
+
+  submat = coef(1)*submatdp + coef(2)*submatsp;
+end
+
+
+% Dirichlet and neumann data corresponding to combined field
+if strcmpi(type,'c2trans') 
+  coef = ones(2,1);
+  if(nargin == 5); coef = varargin{1}; end;
+  targnorm = targinfo.n;
+  srcnorm = srcinfo.n;
+
+  % Get gradient and hessian info
+  [submats,grad,hess] = chnk.helm2d.green(zk,src,targ);
+
+  nxsrc = repmat(srcnorm(1,:),nt,1);
+  nysrc = repmat(srcnorm(2,:),nt,1);
+  nxtarg = repmat((targnorm(1,:)).',1,ns);
+  nytarg = repmat((targnorm(2,:)).',1,ns);
+
+  % D'
+  submatdp = -(hess(:,:,1).*nxsrc.*nxtarg ...
+      + hess(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
+      + hess(:,:,3).*nysrc.*nytarg);
+  % S'
   submatsp = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
   % D
-%  submat(1:2:2*nt,1:2:2*ns)  = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
+  submatd = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
+
+  submat = zeros(2*nt,ns);
+
+  submat(1:2:2*nt,:) = coef(1)*submatd + coef(2)*submats;
+  submat(2:2:2*nt,:) = coef(1)*submatdp + coef(2)*submatsp;
+
+end
+
+
+% all kernels, [c11 D, c12 S; c21 D', c22 S'] 
+if strcmpi(type,'all')
+ 
+  targnorm = targinfo.n;
+  srcnorm = srcinfo.n;
+  cc = varargin{1};
+  
+  submat = zeros(2*nt,2*ns);
+
+  % Get gradient and hessian info
+  [submats,grad,hess] = chnk.helm2d.green(zk,src,targ);
+
+  nxsrc = repmat(srcnorm(1,:),nt,1);
+  nysrc = repmat(srcnorm(2,:),nt,1);
+  nxtarg = repmat((targnorm(1,:)).',1,ns);
+  nytarg = repmat((targnorm(2,:)).',1,ns);
+
+  submatdp = -(hess(:,:,1).*nxsrc.*nxtarg ...
+      + hess(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
+      + hess(:,:,3).*nysrc.*nytarg);
+  % S'
+  submatsp = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
+  % D
   submatd  = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
   
   
@@ -138,8 +222,11 @@ if strcmpi(type,'all')
   submat(2:2:2*nt,2:2:2*ns) = submatsp*cc(2,2);
 end
 
-if strcmpi(type,'eval trans')
+% Dirichlet data/potential correpsonding to transmission rep
+if strcmpi(type,'trans_rep') 
 
+  coef = ones(2,1);
+  if(nargin == 5); coef = varargin{1}; end;
   srcnorm = srcinfo.n;
   [submats,grad] = chnk.helm2d.green(zk,src,targ);
   nx = repmat(srcnorm(1,:),nt,1);
@@ -147,64 +234,43 @@ if strcmpi(type,'eval trans')
   submatd = -(grad(:,:,1).*nx + grad(:,:,2).*ny);
 
   submat = zeros(1*nt,2*ns);
-  submat(1:1:1*nt,1:2:2*ns) = submatd;
-  submat(1:1:1*nt,2:2:2*ns) = submats;
+  submat(1:1:1*nt,1:2:2*ns) = coef(1)*submatd;
+  submat(1:1:1*nt,2:2:2*ns) = coef(2)*submats;
 end
 
-if strcmpi(type,'c and cprime')
+% Neumann data corresponding to transmission rep
+if strcmpi(type,'trans_rep_prime')
+  coef = ones(2,1);
+  if(nargin == 5); coef = varargin{1}; end;
   targnorm = targinfo.n;
   srcnorm = srcinfo.n;
-  coef = varargin{1};
+  
+  submat = zeros(nt,ns);
 
-  submat = zeros(2*nt,1*ns);
-  % S
+  % Get gradient and hessian info
   [submats,grad,hess] = chnk.helm2d.green(zk,src,targ);
-  %[submat(1:2:2*nt,2:2:2*ns),grad,hess] = chnk.helm2d.green(zk,src,targ);
 
   nxsrc = repmat(srcnorm(1,:),nt,1);
   nysrc = repmat(srcnorm(2,:),nt,1);
   nxtarg = repmat((targnorm(1,:)).',1,ns);
   nytarg = repmat((targnorm(2,:)).',1,ns);
+
   % D'
-  %submat(2:2:2*nt,1:2:2*ns) = -(hess(:,:,1).*nxsrc.*nxtarg ... 
   submatdp = -(hess(:,:,1).*nxsrc.*nxtarg ...
       + hess(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
       + hess(:,:,3).*nysrc.*nytarg);
   % S'
-%  submat(2:2:2*nt,2:2:2*ns) = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
   submatsp = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
-  % D
-%  submat(1:2:2*nt,1:2:2*ns)  = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
-  submatd  = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
-  
-  submatc      = coef(1,1) * submatd  + coef(1,2) * submats;
-  submatcprime = coef(2,1) * submatdp + coef(2,2) * submatsp;
-  
-  submat(1:2:2*nt,1:1:1*ns) = submatc;
-  submat(2:2:2*nt,1:1:1*ns) = submatcprime;
-end
-
-if strcmpi(type,'eval')
-  coef = varargin{1};
-  
-  srcnorm = srcinfo.n;
-  
-  submat = zeros(nt,2*ns);
-  % S
-  [submats,grad] = chnk.helm2d.green(zk,src,targ);
-
-  nxsrc = repmat(srcnorm(1,:),nt,1);
-  nysrc = repmat(srcnorm(2,:),nt,1);
-  % D
-  submatd  = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
-    
-  submat(:,1:2:2*ns) = coef(1)*submatd;
-  submat(:,2:2:2*ns) = coef(2)*submats;
+  submat = zeros(nt,2*ns)
+  submat(1:1:1*nt,1:2:2*ns) = coef(1)*submatdp;
+  submat(1:1:1*nt,2:2:2*ns) = coef(2)*submatsp;
 end
 
 
-if strcmpi(type,'evalg')
-  coef = varargin{1};
+% Gradient correpsonding to transmission rep
+if strcmpi(type,'trans_rep_grad')
+  coef = ones(2,1);
+  if(nargin == 5); coef = varargin{1}; end;
   
   srcnorm = srcinfo.n;
   
@@ -216,150 +282,14 @@ if strcmpi(type,'evalg')
   nysrc = repmat(srcnorm(2,:),nt,1);
   % D
   submatd  = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
-    
-  submat(:,:,1) = coef*submatd;
-  submat(:,:,2) = submats;
-  submat(:,:,3) = -coef*(hess(:,:,1).*nxsrc + hess(:,:,2).*nysrc);
-  submat(:,:,4) = grad(:,:,1);
-  submat(:,:,5) = -coef*(hess(:,:,2).*nxsrc + hess(:,:,3).*nysrc);
-  submat(:,:,6) = grad(:,:,2);
-end
 
-
-
-if strcmpi(type,'trans1')
-  %targnorm = chnk.normal2d(targinfo);
-  %srcnorm = chnk.normal2d(srcinfo);
-  % added by Shidong Jiang to avoid O(N^2) calculation of normals
-  targnorm = targinfo.n;
-  srcnorm = srcinfo.n;
-  
-  
-  nxsrc = repmat(srcnorm(1,:),nt,1);
-  nysrc = repmat(srcnorm(2,:),nt,1);
-  nxtarg = repmat((targnorm(1,:)).',1,ns);
-  nytarg = repmat((targnorm(2,:)).',1,ns);
-
-  
   submat = zeros(2*nt,2*ns);
-
-  xs = repmat(src(1,:),nt,1);
-  ys = repmat(src(2,:),nt,1);
-
-  [m,n] = size(xs);
-  xt = repmat(targ(1,:).',1,ns);
-  yt = repmat(targ(2,:).',1,ns);
-
-  rx = xt-xs;
-  ry = yt-ys;
-
-  rx2 = rx.*rx;
-  ry2 = ry.*ry;
-
-  r2 = rx2+ry2;
-
-  r = sqrt(r2);
-  k1 = repmat(targinfo.data(1,:).',1,ns);
-  k2 = repmat(targinfo.data(2,:).',1,ns);
-  c1 = repmat(targinfo.data(3,:).',1,ns);
-  c2 = repmat(targinfo.data(4,:).',1,ns);
   
-  harg1  = k1.*r;
-  hargsz = size(harg1);
-  harg2  = k2.*r;
-  hargsz2= size(harg2);
-  harg = [harg1(:),harg2(:)];
-  %szharg = size(harg)
-  [h00,h11] = chnk.helm2d.besselh01(harg);
-   %[h00,h11] = hankm103(harg);
-  %szh00 = size(h00)
-  h0 = reshape(h00(:,1),hargsz);
-  h1 = reshape(h11(:,1),hargsz);
-  %[h0,h1] = hankm103(k1.*r);
-  %h0 = besselh(0,1,k1.*r);
-  submats1 = 0.25*1i*h0;
-  
-  h1 = h1./r;
-  %h1 = besselh(1,1,k1.*r)./r;
-  
-  grad1 = zeros(m,n,2);
+  submat(1:2:2*nt,1:2:2*ns) = -coef(1)*(hess(:,:,1).*nxsrc + hess(:,:,2).*nysrc);
+  submat(1:2:2*nt,2:2:2*ns) = coef(2)*grad(:,:,1);
     
-  ck = 0.25*1i*k1;
-  grad1(:,:,1) = -ck.*h1.*rx;
-  grad1(:,:,2) = -ck.*h1.*ry;    
-
-  hess1 = zeros(m,n,3);
-
-  h2 = 2*h1./k1-h0;
-  tmp1 = (rx2-ry2).*h1./r2;
-  tmp2 = k1.*h0./r2;
-    
-    
-  hess1(:,:,1) = ck.*(tmp1 - rx2.*tmp2);
-  hess1(:,:,2) = ck.*k1.*rx.*ry.*h2./r2;
-    
-  hess1(:,:,3) = ck.*(-tmp1 - ry2.*tmp2);
-
-  %[submat(1:2:2*nt,2:2:2*ns),grad,hess] = chnk.helm2d.green(zk,src,targ);
-  % D'
-  %submat(2:2:2*nt,1:2:2*ns) = -(hess(:,:,1).*nxsrc.*nxtarg ... 
-  submatdp1 = -(hess1(:,:,1).*nxsrc.*nxtarg ...
-      + hess1(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
-      + hess1(:,:,3).*nysrc.*nytarg);
-  % S'
-%  submat(2:2:2*nt,2:2:2*ns) = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
-  submatsp1 = (grad1(:,:,1).*nxtarg + grad1(:,:,2).*nytarg);
-  % D
-%  submat(1:2:2*nt,1:2:2*ns)  = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
-  submatd1  = -(grad1(:,:,1).*nxsrc + grad1(:,:,2).*nysrc);
- 
-  h0 = reshape(h00(:,2),hargsz2);
-  h1 = reshape(h11(:,2),hargsz2);
-  %[h0,h1] = hankm103(k2.*r);
-  %h0 = besselh(0,1,k2.*r);
-  submats2 = 0.25*1i*h0;
-  
-  %h1 = besselh(1,1,k2.*r)./r;
-  h1 = h1./r;
-  
-  grad2 = zeros(m,n,2);
-    
-  ck = 0.25*1i*k2;
-  grad2(:,:,1) = -ck.*h1.*rx;
-  grad2(:,:,2) = -ck.*h1.*ry;    
-
-  hess2 = zeros(m,n,3);
-
-  h2 = 2*h1./k2-h0;
-  tmp1 = (rx2-ry2).*h1./r2;
-  tmp2 = k2.*h0./r2;
-    
-    
-  hess2(:,:,1) = ck.*(tmp1 - rx2.*tmp2);
-  hess2(:,:,2) = ck.*k2.*rx.*ry.*h2./r2;
-    
-  hess2(:,:,3) = ck.*(-tmp1 - ry2.*tmp2);
-
-  %[submat(1:2:2*nt,2:2:2*ns),grad,hess] = chnk.helm2d.green(zk,src,targ);
-  % D'
-  %submat(2:2:2*nt,1:2:2*ns) = -(hess(:,:,1).*nxsrc.*nxtarg ... 
-  submatdp2 = -(hess2(:,:,1).*nxsrc.*nxtarg ...
-      + hess2(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
-      + hess2(:,:,3).*nysrc.*nytarg);
-  % S'
-%  submat(2:2:2*nt,2:2:2*ns) = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
-  submatsp2 = (grad2(:,:,1).*nxtarg + grad2(:,:,2).*nytarg);
-  % D
-%  submat(1:2:2*nt,1:2:2*ns)  = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
-  submatd2  = -(grad2(:,:,1).*nxsrc + grad2(:,:,2).*nysrc);
-  
-  
-  alpha1 = 2./(c1+c2);
-  alpha2 = 2./(1./c1+1./c2);
-    
-  
-  submat(1:2:2*nt,1:2:2*ns) = alpha1.*(c2.*submatd2-c1.*submatd1);
-  submat(1:2:2*nt,2:2:2*ns) = alpha1.*(submats2-submats1);
-  submat(2:2:2*nt,1:2:2*ns) = -alpha2.*(submatdp2-submatdp1);
-  submat(2:2:2*nt,2:2:2*ns) = -alpha2.*(1./c2.*submatsp2-1./c1.*submatsp1);
+  submat(2:2:2*nt,1:2:2*ns) = -coef(1)*(hess(:,:,2).*nxsrc + hess(:,:,3).*nysrc);
+  submat(2:2:2*nt,2:2:2*ns) = coef(2)*grad(:,:,2);
 end
+
+

--- a/chunkie/+chnk/+lap2d/kern.m
+++ b/chunkie/+chnk/+lap2d/kern.m
@@ -63,9 +63,10 @@ end
 
 if strcmpi(type,'c')
     srcnorm = chnk.normal2d(srcinfo);
-    eta = varargin{1};
+    coef = ones(2,1);
+    if(nargin == 4); coef = varargin{1}; end
     [s,grad] = chnk.lap2d.green(src,targ);
     nx = repmat(srcnorm(1,:),nt,1);
     ny = repmat(srcnorm(2,:),nt,1);
-    submat = -(grad(:,:,1).*nx + grad(:,:,2).*ny) + eta*s;
+    submat = -coef(1)*(grad(:,:,1).*nx + grad(:,:,2).*ny) + coef(2)*s;
 end

--- a/chunkie/@chunkgraph/chunkgraph.m
+++ b/chunkie/@chunkgraph/chunkgraph.m
@@ -21,12 +21,108 @@ classdef chunkgraph
         n
         adj
         sourceinfo
-        npts
+        npt
     end
     
     methods
-        function obj = chunkgraph(p)
-        
+        function obj = chunkgraph(verts,edge2verts,fchnks,cparams)
+            if (nargin == 0)
+                return
+            end
+            if (numel(verts)==0)
+                return
+            end
+            obj.verts      = verts;
+            obj.edge2verts = edge2verts;
+            obj.echnks     = chunker.empty;
+            
+            if (nargin < 4)
+                cploc = [];
+                cploc.ta = 0;
+                cploc.tb = 1;
+                cploc.ifclosed = 0;
+                cploc.nover = 1;
+                cploc.eps = 1.0d-10;
+                cploc.lvlr = 'a';
+            else
+                cploc = cparams;
+                %mandatory settings
+                cploc.ta = 0;
+                cploc.tb = 1;
+                cploc.ifclosed = 0;
+                if (~isfield(cparams,'lvlr'))
+                    cploc.lvlr = 'a';
+                end
+                if (~isfield(cparams,'eps'))
+                    cploc.eps = 1.0d-10;
+                end
+                if (~isfield(cparams,'nover'))
+                    cploc.nover = 1;
+                end
+            end
+            
+            
+            pref = [];
+            pref.nchmax = 10000;
+            pref.k = 16;
+            
+            if (size(verts,2) ~= size(edge2verts,2))
+                error('Incompatible vertex and edge sizes');
+            end
+            
+            echnks = chunker.empty();
+            for i=1:size(edge2verts,1)
+                if (numel(fchnks)<i || isempty(fchnks{i}))
+                    i1 = find(edge2verts(i,:)==-1);
+                    i2 = find(edge2verts(i,:)==1);
+                    v1 = verts(:,i1);
+                    v2 = verts(:,i2);
+                    fcurve = @(t) chnk.curves.linefunc(t,v1,v2);
+                    chnkr = chunkerfunc(fcurve,cploc,pref);
+                    chnkr = sort(chnkr);
+                    %chnkr.vert = [v1,v2];
+                    echnks(i) = chnkr;
+                elseif (~isempty(fchnks{i}) && isa(fchnks{i},'function_handle'))
+                    [vs,~,~] =fchnks{i}([0,1]);
+                    chnkr = chunkerfunc(fchnks{i},cploc,pref);
+                    chnkr = sort(chnkr);
+                    vfin0 = verts(:,find(edge2verts(i,:)==-1));
+                    vfin1 = verts(:,find(edge2verts(i,:)== 1));
+                    r0 = vs(:,1);
+                    r1 = vfin0;
+                    scale = norm(vfin1-vfin0,'fro')/norm(vs(:,2)-vs(:,1),'fro');
+                    xdfin = vfin1(1)-vfin0(1);
+                    ydfin = vfin1(2)-vfin0(2);
+                    tfin = atan2(ydfin,xdfin);
+                    xdini = vs(1,2)-vs(1,1);
+                    ydini = vs(2,2)-vs(2,1);
+                    tini = atan2(ydini,xdini);
+                    trotat = tfin - tini;
+                    chnkr = move(chnkr,r0,r1,trotat,scale);
+                    echnks(i) = chnkr;
+                end
+            end
+            obj.echnks = echnks;
+            obj.vstruc = procverts(obj);
+            %[regions] = findregions(obj);
+            %obj.regions = regions;
+            
+            adjmat = edge2verts'*edge2verts;
+            g = graph(adjmat);
+            ccomp = conncomp(g);
+            
+            chnkcomp = {};
+            regions = {};
+            
+            for i=1:max(ccomp)
+                inds = find(ccomp==i);
+                chnkcomp{i} = inds;
+                [region_comp] = findregions(obj,inds);
+                [region_comp] = findunbounded(obj,region_comp);
+                regions{i} = region_comp;
+            end
+            
+            obj.regions = regions;
         end
         function obj = set.verts(obj,val)
             classes = {'numeric'};
@@ -63,16 +159,16 @@ classdef chunkgraph
             chnk = merge(obj.echnks);
             adj = chnk.adj;
         end
-        function npts = get.npts(obj)
-            npts = 0;
+        function npt = get.npt(obj)
+            npt = 0;
             for iedge = 1:numel(obj.echnks)
             	n = size(obj.echnks(iedge).r(:,:),2);
-                npts = n + npts;
+                npt = n + npt;
             end
         end
         function sourceinfo = get.sourceinfo(obj)
             sourceinfo = [];
-            ntot = obj.npts;
+            ntot = obj.npt;
             rs = zeros(2,ntot);
             ds = zeros(2,ntot);
             d2s= zeros(2,ntot);

--- a/chunkie/@kernel/helm2d.m
+++ b/chunkie/@kernel/helm2d.m
@@ -46,13 +46,13 @@ switch lower(type)
     case {'sp', 'sprime'}
         obj.type = 'sp';
         obj.eval = @(s,t) chnk.helm2d.kern(zk, s, t, 'sprime');
-        % TODO: Add FMM for sprime.
+        obj.fmm  = @(eps,s,t,sigma) chnk.helm2d.fmm(eps, zk, s, t, 'sprime', sigma, 1);
         obj.sing = 'log';
 
     case {'dp', 'dprime'}
         obj.type = 'dp';
         obj.eval = @(s,t) chnk.helm2d.kern(zk, s, t, 'dprime');
-        % TODO: Add FMM for sprime.
+        obj.fmm  = @(eps,s,t,sigma) chnk.helm2d.fmm(eps, zk, s, t, 'dprime', sigma, 1);
         obj.sing = 'hs';
 
     case {'c', 'combined'}

--- a/chunkie/@kernel/kernel.m
+++ b/chunkie/@kernel/kernel.m
@@ -82,6 +82,8 @@ classdef kernel
           end
 
       end
+      
+      
 
     end
 

--- a/chunkie/@kernel/lap2d.m
+++ b/chunkie/@kernel/lap2d.m
@@ -1,4 +1,4 @@
-function obj = lap2d(type, eta)
+function obj = lap2d(type, coefs)
 %KERNEL.LAP2D   Construct the Laplace kernel.
 %   KERNEL.LAP2D('s') or KERNEL.LAP2D('single') constructs the single-layer
 %   Laplace kernel.
@@ -9,7 +9,7 @@ function obj = lap2d(type, eta)
 %   KERNEL.LAP2D('sp') or KERNEL.LAP2D('sprime') constructs the derivative
 %   of the single-layer Laplace kernel.
 %
-%   KERNEL.LAP2D('c', ETA) or KERNEL.LAP2D('combined', ETA) constructs the
+%   KERNEL.LAP2D('c', coefs) or KERNEL.LAP2D('combined', coefs) constructs the
 %   combined-layer Laplace kernel with parameter ETA, i.e.,
 %   KERNEL.LAP2D('d') + eta*KERNEL.LAP2D('s').
 %
@@ -40,19 +40,19 @@ switch lower(type)
     case {'sp', 'sprime'}
         obj.type = 'sp';
         obj.eval = @(s,t) chnk.lap2d.kern(s, t, 'sprime');
-        % TODO: FMM for sprime.
+        obj.fmm  = @(eps,s,t,sigma) chnk.lap.fmm(eps, s, t, 'sprime', sigma, 1);
         obj.sing = 'smooth';
 
     case {'st', 'stau'}
         obj.type = 'st';
         obj.eval = @(s,t) chnk.lap2d.kern(s, t, 'stau');
-        % TODO: FMM for stau.
+        obj.fmm  = @(eps,s,t,sigma) chnk.lap.fmm(eps, s, t, 'stau', sigma, 1);
         obj.sing = 'pv';
 
     case {'dp', 'dprime'}
         obj.type = 'dp';
         obj.eval = @(s,t) chnk.lap2d.kern(s, t, 'dprime');
-        % TODO: FMM for sprime.
+        obj.fmm  = @(eps,s,t,sigma) chnk.lap.fmm(eps, s, t, 'dprime', sigma, 1);
         obj.sing = 'hs';
 
     case {'sg', 'sgrad'}
@@ -71,13 +71,13 @@ switch lower(type)
 
     case {'c', 'combined'}
         if ( nargin < 2 )
-            warning('Missing combined layer parameter eta. Defaulting to 1.');
-            eta = 1;
+            warning('Missing combined layer parameter coefs. Defaulting to 1.');
+            coefs = ones(2,1);
         end
         obj.type = 'c';
-        obj.params.eta = eta;
-        obj.eval = @(s,t) chnk.lap2d.kern(s, t, 'c', eta);
-        obj.fmm  = @(eps,s,t,sigma,pgt) chnk.lap2d.fmm(eps, s, t, 'c', sigma, pgt, eta);
+        obj.params.coefs = coefs;
+        obj.eval = @(s,t) chnk.lap2d.kern(s, t, 'c', coefs);
+        obj.fmm  = @(eps,s,t,sigma,pgt) chnk.lap2d.fmm(eps, s, t, 'c', sigma, pgt, coefs);
         obj.sing = 'log';
 
     otherwise

--- a/chunkie/@kernel/mtimes.m
+++ b/chunkie/@kernel/mtimes.m
@@ -1,0 +1,8 @@
+function f = mtimes(f,g)
+% * Martix multiplication for kernel
+%
+% Currently only supports scalars
+%
+% returns c*F or F*C for the kernel F and scalar c
+   f = times(f,g);
+end

--- a/chunkie/@kernel/times.m
+++ b/chunkie/@kernel/times.m
@@ -1,0 +1,38 @@
+function f = times(f,g)
+% .* Pointwise multiplication for kernel class
+%
+% Currently only supported for scalars, if g is a scalar
+% then f.*g or g.*f returns a kernel class object where each
+% of the function handles - eval, and fmm are multiplied by 
+% g
+
+if (~isa(f,'kernel'))
+    f = times(g,f);
+    return
+elseif (isscalar(g))
+    if(isa(f.eval, 'function_handle'))
+        feval_str = func2str(f.eval);  
+        fstr_split = split(feval_str,')');
+        fstr_split{2} = [num2str(double(g)) '*' fstr_split{2}];
+        fstr_join = join(fstr_split,')');
+        f.eval = str2func(fstr_join{1});
+    else
+        f.eval = [];
+    end
+    
+    if(isa(f.fmm, 'function_handle'))
+        ffmm_str = func2str(f.fmm);  
+        fstr_split = split(ffmm_str,')');
+        fstr_split{2} = [num2str(double(g)) '*' fstr_split{2}];
+        fstr_join = join(fstr_split,')');
+        f.fmm = str2func(fstr_join{1});
+    else
+        f.fmm = [];
+    end
+    
+else
+    error('KERNEL:times:invalid', ...
+       'F or G must be scalar and the other a kernel class object');
+end
+end
+

--- a/chunkie/chunkerflam.m
+++ b/chunkie/chunkerflam.m
@@ -223,7 +223,7 @@ else
     warning('specified quadrature method not available');
     return;
 end
-sp = chunkermat(chnkrs,kern,chunkermatopt);
+sp = chunkermat(chnkobj,kern,chunkermatopt);
 sp = sp + spdiags(dval,0,nrows,nrows);
 
 % prep and call flam

--- a/chunkie/chunkermat.m
+++ b/chunkie/chunkermat.m
@@ -295,10 +295,12 @@ for i = 1:nchunkers
                 icolinds = icollocs(j):(icollocs(j+1)-1);
                 sysmat(irowinds,icolinds) = sysmat_tmp;
             else
-                [isys,jsys,vsys] = find(sysmat_tmp);
-                isysmat = [isysmat;isys+irowlocs(i)-1];
-                jsysmat = [jsysmat;jsys+icollocs(j)-1];
-                vsysmat = [vsysmat;vsys];
+                if adaptive_correction
+                    [isys,jsys,vsys] = find(sysmat_tmp);
+                    isysmat = [isysmat;isys+irowlocs(i)-1];
+                    jsysmat = [jsysmat;jsys+icollocs(j)-1];
+                    vsysmat = [vsysmat;vsys];
+                end
             end
         end
     end
@@ -442,7 +444,6 @@ if(icgrph && isrcip)
     
     
     for ivert=1:nv
-        fprintf('ivert=%d\n',ivert);
         clist = chnkobj.vstruc{ivert}{1};
         isstart = chnkobj.vstruc{ivert}{2};
         isstart(isstart==1) = 0;
@@ -493,9 +494,10 @@ if(icgrph && isrcip)
             
             sysmat(starind,starind) = sysmat_tmp;
         else
+            [jind,iind] = meshgrid(starind);
             
-            isysmat = [isysmat;starind];
-            jsysmat = [jsysmat;starind];
+            isysmat = [isysmat;iind(:)];
+            jsysmat = [jsysmat;jind(:)];
             vsysmat = [vsysmat;sysmat_tmp(:)];
         end    
     end
@@ -504,8 +506,15 @@ end
 
 
 
+
 if (nonsmoothonly)
-    sysmat = sparse(isysmat,jsysmat,vsysmat,nrows,ncols);
+    % Fix sparse entry format to use rcip matrix entries for repeats
+    % instead of using the precomputed self correction
+    
+    ijind = [isysmat jsysmat];
+    [~,idx] = unique(ijind, 'rows','last');
+    
+    sysmat = sparse(isysmat(idx),jsysmat(idx),vsysmat(idx),nrows,ncols);
 end
 
 

--- a/devtools/test/chunkermat_quadadap_closetotouchingTest.m
+++ b/devtools/test/chunkermat_quadadap_closetotouchingTest.m
@@ -72,7 +72,7 @@ utarg = kernmatstarg*strengths;
 % use adaptive routine to build matrix (self done by ggq, nbor by adaptive)
 
 eta = 1;
-fkern = @(s,t) chnk.lap2d.kern(s,t,'C',eta);
+fkern = @(s,t) chnk.lap2d.kern(s,t,'C',[1,eta]);
 
 type = 'log';
 opts = []; opts.robust = true;

--- a/devtools/test/chunkrgrphOpdimTest.m
+++ b/devtools/test/chunkrgrphOpdimTest.m
@@ -34,12 +34,12 @@ cgrph = balance(cgrph);
 
 zk0 = 1; % exterior
 zk1 = 3; % interior
-eta = [1 -1j*real(zk0); 1 -1j*real(zk0)]; % this numbers might be wrong...
+coef = [1 -1j*real(zk0)]; 
 cc = [1 1; 1 1]; % these numbers might be wrong... 
 
 fkern11 = @(s,t) chnk.helm2d.kern(zk0,s,t,'all',cc) - chnk.helm2d.kern(zk1,s,t,'all',cc);
-fkern12 = @(s,t) chnk.helm2d.kern(zk0,s,t,'c and cprime',eta);
-fkern21 = @(s,t) chnk.helm2d.kern(zk0,s,t,'eval trans');
+fkern12 = @(s,t) chnk.helm2d.kern(zk0,s,t,'c2trans',coef);
+fkern21 = @(s,t) chnk.helm2d.kern(zk0,s,t,'trans_rep');
 fkern22  = @(s,t) chnk.helm2d.kern(zk0,s,t,'c',[1,1i]);
 
 chnk_trans_flag = [1 1 1 1 0 0 0 0];

--- a/devtools/test/flamutilitiesTest.m
+++ b/devtools/test/flamutilitiesTest.m
@@ -9,33 +9,49 @@ rng(iseed);
 
 addpaths_loc();
 
+nverts = 3; 
+verts = exp(1i*2*pi*(0:(nverts-1))/nverts);
+verts = [real(verts);imag(verts)];
+
+
+iind = 1:nverts;
+jind = 1:nverts;
+
+iind = [iind iind];
+jind = [jind jind + 1];
+jind(jind>nverts) = 1;
+svals = [-ones(1,nverts) ones(1,nverts)];
+edge2verts = sparse(iind,jind,svals,nverts,nverts);
+
+amp = 0.1;
+frq = 2;
+fchnks    = cell(1,size(edge2verts,1));
+for icurve = 1:size(edge2verts,1)
+    fchnks{icurve} = @(t) sinearc(t,amp,frq);
+end
 cparams = [];
-cparams.eps = 1.0e-10;
-cparams.nover = 5;
-pref = []; 
-pref.k = 32;
-narms = 3;
-amp = 0.25;
-start = tic; chnkr = chunkerfunc(@(t) starfish(t,narms,amp),cparams,pref); 
-t1 = toc(start);
+cparams.nover = 2;
+[cgrph] = chunkgraphinit(verts,edge2verts,fchnks,cparams);
 
-wts = weights(chnkr); wts = wts(:);
+vstruc = procverts(cgrph);
+rgns = findregions(cgrph);
+cgrph = balance(cgrph);
 
-fprintf('%5.2e s : time to build geo\n',t1)
+
+wts = weights(cgrph); wts = wts(:);
 
 % sources
 
 ns = 10;
 ts = 0.0+2*pi*rand(ns,1);
-sources = starfish(ts,narms,amp);
-sources = 3.0*sources;
+sources = 3.0*[cos(ts)';sin(ts)'];
 strengths = randn(ns,1);
 
 % targets
 
 nt = 1;
 ts = 0.0+2*pi*rand(nt,1);
-targets = starfish(ts,narms,amp);
+targets = 0.2*[cos(ts)'; sin(ts)'];
 targets = targets.*repmat(rand(1,nt),2,1);
 
 % plot geo and sources
@@ -43,7 +59,7 @@ targets = targets.*repmat(rand(1,nt),2,1);
 figure(1)
 clf
 hold off
-plot(chnkr)
+plot(cgrph)
 hold on
 scatter(sources(1,:),sources(2,:),'o')
 scatter(targets(1,:),targets(2,:),'x')
@@ -56,8 +72,8 @@ kerns = kernel('lap','s');
 % eval u on bdry
 
 srcinfo = []; srcinfo.r = sources;
-targinfo = []; targinfo.r = chnkr.r(:,:); 
-targinfo.d = chnkr.d(:,:);
+targinfo = []; targinfo.r = cgrph.r(:,:); 
+targinfo.d = cgrph.d(:,:);
 ubdry = kerns.fmm(1e-12,srcinfo,targinfo,strengths,1);
 
 % eval u at targets
@@ -67,63 +83,70 @@ utarg = kerns.fmm(1e-12,srcinfo,targinfo,strengths,1);
 
 %
 
-% build laplace dirichlet matrix
+% build laplace dirichlet matrix * (-2)
 
-kernd = kernel('lap','d');
-start = tic; D = chunkermat(chnkr,kernd);
+kernd = -2*kernel('lap','d');
+
+opts = [];
+opts.rcip = true;
+start = tic; D = chunkermat(cgrph,kernd,opts);
 t1 = toc(start);
 
 fprintf('%5.2e s : time to assemble matrix\n',t1)
 
-sys = -0.5*eye(chnkr.k*chnkr.nch) + D;
+npt = cgrph.npt;
+sys = eye(npt) + D;
 
 % build sparse tridiag part 
 
 opts.nonsmoothonly = true;
-start = tic; spmat = chunkermat(chnkr,kernd,opts);
+opts.rcip = true;
+start = tic; spmat = chunkermat(cgrph,kernd,opts);
 t1 = toc(start);
 fprintf('%5.2e s : time to build tridiag\n',t1)
 
-spmat = spmat -0.5*speye(chnkr.npt);
+spmat = spmat + speye(npt);
 
 % test matrix entry evaluator
 start = tic; 
 % opdims = [1 1];
 opdims = ones([2,1,1]);
 
-sys2 = chnk.flam.kernbyindex(1:chnkr.npt,1:chnkr.npt,chnkr,wts,kernd,opdims,spmat);
+sys2 = chnk.flam.kernbyindex(1:npt,1:npt,cgrph,wts,kernd,opdims,spmat);
+
+
 t1 = toc(start);
 
 fprintf('%5.2e s : time for mat entry eval on whole mat\n',t1)
 
+err2 = norm(sys2-sys,'fro')/norm(sys,'fro');
+fprintf('%5.2e   : fro error of build \n',err2)
 
-xflam = chnkr.r(:,:);
-matfun = @(i,j) chnk.flam.kernbyindex(i,j,chnkr,wts,kernd,opdims,spmat);
+
+xflam = cgrph.r(:,:);
+matfun = @(i,j) chnk.flam.kernbyindex(i,j,cgrph,wts,kernd,opdims,spmat);
 [pr,ptau,pw,pin] = chnk.flam.proxy_square_pts();
 ifaddtrans = true;
-pxyfun = @(x,slf,nbr,l,ctr) chnk.flam.proxyfun(slf,nbr,l,ctr,chnkr,wts, ...
+pxyfun = @(x,slf,nbr,l,ctr) chnk.flam.proxyfun(slf,nbr,l,ctr,cgrph,wts, ...
     kernd,opdims,pr,ptau,pw,pin,ifaddtrans);
 
 
 start = tic; F = rskelf(matfun,xflam,200,1e-14,pxyfun); t1 = toc(start);
-F = chunkerflam(chnkr,kernd,-0.5);
+F = chunkerflam(cgrph,kernd,1.0);
 
 fprintf('%5.2e s : time for flam rskelf compress\n',t1)
 
 pxyfunr = @(rc,rx,cx,slf,nbr,l,ctr) chnk.flam.proxyfunr(rc,rx,slf,nbr,l, ...
-        ctr,chnkr,wts,kernd,opdims,pr,ptau,pw,pin);
+        ctr,cgrph,wts,kernd,opdims,pr,ptau,pw,pin);
 
 opts = [];
 start = tic; F2 = rskel(matfun,xflam,xflam,200,1e-14,pxyfunr,opts); t1 = toc(start);
 
 fprintf('%5.2e s : time for flam rskel compress\n',t1)
 
-afun = @(x) rskelf_mv(F,x);
+afun = @(x) rskelf_mv(F2,x);
 
 
-
-err2 = norm(sys2-sys,'fro')/norm(sys,'fro');
-fprintf('%5.2e   : fro error of build \n',err2)
 
 rhs = ubdry; rhs = rhs(:);
 start = tic; sol = gmres(sys,rhs,[],1e-14,100); t1 = toc(start);
@@ -146,16 +169,34 @@ assert(err < 1e-10);
 opts.usesmooth=false;
 opts.verb=false;
 opts.quadkgparams = {'RelTol',1e-16,'AbsTol',1.0e-16};
-start=tic; Dsol = chunkerkerneval(chnkr,kernd,sol3,targets,opts); 
+
+% Collapse cgrph into chnkrtotal
+chnkrs = cgrph.echnks;
+chnkrtotal = merge(chnkrs);
+start=tic; Dsol = chunkerkerneval(chnkrtotal,kernd,sol3,targets,opts); 
 t1 = toc(start);
 fprintf('%5.2e s : time to eval at targs (slow, adaptive routine)\n',t1)
 
 %
 
-wchnkr = weights(chnkr);
+wcgrph = weights(cgrph);
 
-relerr = norm(utarg-Dsol,'fro')/(sqrt(chnkr.nch)*norm(utarg,'fro'));
-relerr2 = norm(utarg-Dsol,'inf')/dot(abs(sol(:)),wchnkr(:));
+relerr = norm(utarg-Dsol,'fro')/(sqrt(chnkrtotal.nch)*norm(utarg,'fro'));
+relerr2 = norm(utarg-Dsol,'inf')/dot(abs(sol(:)),wcgrph(:));
 fprintf('relative frobenius error %5.2e\n',relerr);
 fprintf('relative l_inf/l_1 error %5.2e\n',relerr2);
 
+
+
+function [r,d,d2] = sinearc(t,amp,frq)
+xs = t;
+ys = amp*sin(frq*t);
+xp = ones(size(t));
+yp = amp*frq*cos(frq*t);
+xpp = zeros(size(t));
+ypp = -frq*frq*amp*sin(t);
+
+r = [(xs(:)).'; (ys(:)).'];
+d = [(xp(:)).'; (yp(:)).'];
+d2 = [(xpp(:)).'; (ypp(:)).'];
+end


### PR DESCRIPTION
Fixed chunkermat behavior for non smooth only, tested through flamutilities.m in devtools
Fixed chunkerflam along the way
Added capability for overloading multiplication operator for kernel class - had to go an indirect route since multiplication is not supported on function handles
Added missing fmm pieces for Laplace and Helmholtz
made consistent the behavior of combined field representations
Refixed npts -> npt in chunkergraph

