### PR TITLE
changing rcip opts

### DIFF
--- a/chunkie/@chunker/max.m
+++ b/chunkie/@chunker/max.m
@@ -17,4 +17,4 @@ function rmax = max(obj)
 
 % author: Travis Askham (askhamwhat@gmail.com)
 
-rmax = max(reshape(obj.r,obj.dim,obj.k*obj.nch),[],2);
+rmax = max(real(reshape(obj.r,obj.dim,obj.k*obj.nch)),[],2);

--- a/chunkie/@chunker/min.m
+++ b/chunkie/@chunker/min.m
@@ -17,4 +17,4 @@ function rmin = min(obj)
 
 % author: Travis Askham (askhamwhat@gmail.com)
 
-rmin = min(reshape(obj.r,obj.dim,obj.k*obj.nch),[],2);
+rmin = min(real(reshape(obj.r,obj.dim,obj.k*obj.nch)),[],2);

--- a/chunkie/chunkerflam.m
+++ b/chunkie/chunkerflam.m
@@ -244,7 +244,7 @@ for i=1:nchunkers
     mmax = max([mmax,max(chnkr)],[],2);
     mmin = min([mmin,min(chnkr)],[],2);
 end
-
+xflam = real(xflam);
 width = max(mmax-mmin);
 
 chnkrtotal = merge(chnkrs);

--- a/chunkie/chunkermat.m
+++ b/chunkie/chunkermat.m
@@ -485,11 +485,12 @@ if(icgrph && isrcip)
 
         [Pbc,PWbc,starL,circL,starS,circS,ilist,starL1,circL1] = ...
             chnk.rcip.setup(ngl,ndim,nedge,isstart);
-        
-        % this might need to be fixed in triple junction case
+        optsrcip = opts;
+        optsrcip.nonsmoothonly = false;
+
         R = chnk.rcip.Rcompchunk(chnkrs,iedgechunks,kern,ndim, ...
             Pbc,PWbc,nsub,starL,circL,starS,circS,ilist,starL1,circL1,... 
-            sbclmat,sbcrmat,lvmat,rvmat,u,opts);
+            sbclmat,sbcrmat,lvmat,rvmat,u,optsrcip);
        
         sysmat_tmp = inv(R) - eye(2*ngl*nedge*ndim);
         if (~nonsmoothonly)

--- a/devtools/test/flamutilitiesTest.m
+++ b/devtools/test/flamutilitiesTest.m
@@ -106,14 +106,16 @@ t1 = toc(start);
 fprintf('%5.2e s : time to build tridiag\n',t1)
 
 spmat = spmat + speye(npt);
+inds = find(spmat);
+spmat(inds) = sys(inds);
 
 % test matrix entry evaluator
 start = tic; 
-% opdims = [1 1];
-opdims = ones([2,1,1]);
+ opdims = [1 1];
+%opdims = ones([2,1,1]);
 
+%sys2 = chnk.flam.kernbyindex(1:npt,1:npt,cgrph,kernd,opdims,spmat);
 sys2 = chnk.flam.kernbyindex(1:npt,1:npt,cgrph,kernd,opdims,spmat);
-
 
 
 t1 = toc(start);
@@ -122,6 +124,8 @@ fprintf('%5.2e s : time for mat entry eval on whole mat\n',t1)
 
 err2 = norm(sys2-sys,'fro')/norm(sys,'fro');
 fprintf('%5.2e   : fro error of build \n',err2)
+
+ assert(err2 < 1e-10);
 
 
 xflam = cgrph.r(:,:);
@@ -163,7 +167,7 @@ err = norm(sol-sol3,'fro')/norm(sol,'fro');
 
 fprintf('difference between fast-direct and iterative %5.2e\n',err)
 
-% assert(err < 1e-10);
+ assert(err < 1e-10);
 
 % evaluate at targets and compare
 


### PR DESCRIPTION
There was a bug when nonsmoothonly was called with rcip - the flag was being passed to chunkermat from rcip. 
Real was added to a few places to make complex chunks a little easier to work with