### PR TITLE
chunkerkerneval on graphs

### DIFF
--- a/chunkie/@kernel/nans.m
+++ b/chunkie/@kernel/nans.m
@@ -1,12 +1,12 @@
-function obj = zeros(m, n)
-%KERNEL.ZEROS   Construct the zero kernel.
-%   KERNEL.ZEROS() constructs the zero kernel with operator dimensions
+function obj = nans(m, n)
+%KERNEL.NAN   Construct the nan kernel.
+%   KERNEL.NAN() constructs the nan kernel with operator dimensions
 %   of 1 x 1.
 %
-%   KERNEL.ZEROS(N) constructs the zero kernel with operator dimensions
+%   KERNEL.NAN(N) constructs the nan kernel with operator dimensions
 %   of N x N.
 %
-%   KERNEL.ZEROS(M, N) constructs the zero kernel with operator dimensions
+%   KERNEL.NAN(M, N) constructs the NAN kernel with operator dimensions
 %   of M x N.
 
 if ( nargin < 1 )
@@ -20,13 +20,13 @@ end
     function out = eval_(s, t)
         [~, ns] = size(s.r);
         [~, nt] = size(t.r);
-        out = zeros(m*nt, n*ns);
+        out = nan(m*nt, n*ns);
     end
 
     function out = shifted_eval_(s, t, o)
         [~, ns] = size(s.r);
         [~, nt] = size(t.r);
-        out = zeros(m*nt, n*ns);
+        out = nan(m*nt, n*ns);
     end
 
     function varargout = fmm_(eps, s, t, sigma)
@@ -37,22 +37,22 @@ end
             [~, nt] = size(t);
         end
 
-        if ( nargout > 0 ), varargout{1} = zeros(m*nt, 1); end
-        if ( nargout > 1 ), varargout{2} = zeros(2, m*nt); end
-        if ( nargout > 2 ), varargout{3} = zeros(3, m*nt); end
+        if ( nargout > 0 ), varargout{1} = nan(m*nt, 1); end
+        if ( nargout > 1 ), varargout{2} = nan(2, m*nt); end
+        if ( nargout > 2 ), varargout{3} = nan(3, m*nt); end
         if ( nargout > 3 )
-            error('CHUNKIE:kernel:zeros', 'Too many output arguments for FMM.');
+            error('CHUNKIE:kernel:nan', 'Too many output arguments for FMM.');
         end
 
     end
 
 obj = kernel();
-obj.name   = 'zeros';
+obj.name   = 'nans';
 obj.opdims = [m n];
 obj.sing   = 'smooth';
 obj.eval   = @eval_;
 obj.shifted_eval   = @shifted_eval_;
 obj.fmm    = @fmm_;
-obj.iszero = true;
+obj.isnan = true;
 
 end

--- a/chunkie/@kernel/plus.m
+++ b/chunkie/@kernel/plus.m
@@ -1,0 +1,30 @@
+function f = plus(f,g)
+% + Pointwise addition for kernel class
+%
+% Currently only supported for adding two kernel class objects
+% or adding a scalar to a kernel class object.
+
+if (isa(g,'kernel') && isa(f,'kernel'))
+  assert(f.opdims(1) == g.opdims(1) && f.opdims(1) == g.opdims(2), ...
+      'kernel dimensions must agree to add');
+  f.name = ['custom ',f.name,' ',g.name];
+  f.eval = @(varargin) g.eval(varargin{:}) + f.eval(varargin{:});
+  if (isa(g.fmm,'function_handle') && isa(f.fmm,'function_handle'))
+    f.fmm = @(varargin) g.fmm(varargin{:}) + f.fmm(varargin{:});
+  else
+    f.fmm = [];
+  end
+  if or(f.isnan,g.isnan)
+      f = kernel.nans(f.opdims(1),f.opdims(2));
+  end
+  if and(f.iszero,g.iszero)
+      f.iszero = true;
+  else
+      f.iszero = false;
+  end
+else
+    error('KERNEL:plus:invalid', ...
+       'F and G must be either floats or kernel class objects');
+end
+end
+

--- a/chunkie/@kernel/times.m
+++ b/chunkie/@kernel/times.m
@@ -27,6 +27,13 @@ elseif (isscalar(g))
     else
         f.fmm = [];
     end
+
+    if or(f.isnan,isnan(g))
+        f = kernel.nans(f.opdims(1),f.opdims(2));
+    end
+    if ~f.isnan && (g==0) || f.iszero && ~isnan(g)
+        f = kernel.zeros(f.opdims(1),f.opdims(2));
+    end
     
 else
     error('KERNEL:times:invalid', ...

--- a/chunkie/chunkermat.m
+++ b/chunkie/chunkermat.m
@@ -186,7 +186,7 @@ for i=1:nchunkers
     targinfo = [];
    	targinfo.r = chnkrs(i).r(:,2); targinfo.d = chnkrs(i).d(:,2); 
    	targinfo.d2 = chnkrs(i).d2(:,2); targinfo.n = chnkrs(i).n(:,2);
-    lchunks(i) = size(chnkrs(i).r(:,:),2);
+    lchunks(i) = chnkrs(i).npt;
     
     for j=1:nchunkers
         

--- a/devtools/test/chunkerclassunitTest.m
+++ b/devtools/test/chunkerclassunitTest.m
@@ -1,0 +1,51 @@
+%chunkerclassunitTest
+%
+% setting up some tests for methods of the chunker class
+%
+
+addpaths_loc();
+% adversarial constructor tests
+isuccess = 0;
+try
+    pref = []; pref.k = -1;
+    chnkr = chunker(pref);
+catch
+    isuccess = 1;
+end
+assert(isuccess);
+
+isuccess = 0;
+try
+    pref = []; pref.k = 9; [t,w] = lege.exps(8);
+    chnkr = chunker(pref,t,w);
+catch
+    isuccess = 1;
+end
+assert(isuccess);
+
+isuccess = 0;
+try
+    cparams = []; 
+    pref = []; pref.k=4; pref.nchmax = 100;
+    chnkr = chunkerfunc(@(t) starfish(t),cparams,pref);
+catch
+    isuccess = 1;
+end
+assert(isuccess);
+
+cparams = []; cparams.chsmall = 1e-14; cparams.ifclosed=0;
+cparams.tb = 2*pi-0.01; cparams.nover=1;
+pref = []; pref.k=16; pref.nchmax = 10000;
+chnkr = chunkerfunc(@(t) starfish(t),cparams,pref);
+
+
+for j = 1:chnkr.nch
+i1 = chnkr.adj(1,j);
+i2 = chnkr.adj(2,j);
+if (i1 > 0)
+assert(chnkr.adj(2,i1) == j)
+end
+if (i2 > 0)
+assert(chnkr.adj(1,i2) == j)
+end
+end

--- a/devtools/test/kernel_interleaveTest.m
+++ b/devtools/test/kernel_interleaveTest.m
@@ -4,6 +4,19 @@ rng(iseed);
 
 addpaths_loc();
 
+% dumb test 
+
+K0 = [kernel.lap2d('d'), kernel.nans()];
+didfail = false;
+try 
+    K0 = interleave(K0);
+catch
+    didfail = true;
+end
+assert(didfail)
+
+% solver test
+
 zk = 1.1;
 
 cparams = [];

--- a/devtools/test/kernelclassTest.m
+++ b/devtools/test/kernelclassTest.m
@@ -89,3 +89,12 @@ fprintf('relative frobenius error %5.2e\n',relerr);
 
 assert(relerr < 1e-11);
 
+nankern = kernel.nans();
+assert(nankern.isnan);
+
+kerntmp = kernd + nankern;
+assert(kerntmp.isnan);
+
+kerntmp = nan*kerns;
+assert(kerntmp.isnan);
+


### PR DESCRIPTION
this allows you to have a nregion x nedge matrix of kernels in chunkerkerneval. Also accepts 1x1, 1xnedge, and nregion x 1.

This is tested in mixedbcTest.m 

I also added a nans kernel to the kernel class. I also added fields to the kernels that indicate if the kernel is zero or nan. I updated the add and scale kernel functions to do something reasonable. e.g. 
nan*kern is a nan kernel
0*kern is a zero kernel except if kern is a nan kernel
c*kern is nan if kern is nan
kern1+kern2 is nan if kern1 or kern2 is nan
kern1+kern2 is zero if kern1 and kern2 are zero

The idea is that if the chunkerkerneval routine knows that the kernel is zero or nan it can do no work for that interaction. 

Perhaps later, it may be reasonable to allow a 2x1 kernel matrix for a closed chunker geometry, which would apply the first kernel in the exterior and the second in the interior (following the unbounded region convention from chunkgraph).