### PR TITLE
remove spurious warning in chunkermat with quad=native

### DIFF
--- a/chunkie/chunkermat.m
+++ b/chunkie/chunkermat.m
@@ -410,10 +410,6 @@ for i=1:nchunkers
         if nonsmoothonly
             sysmat_tmp = sparse(chnkr.npt,chnkr.npt);
         else
-            if (quadorder ~= chnkr.k)
-                warning(['native rule: quadorder', ... 
-                    ' must equal chunker order (%d)'],chnkr.k)
-            end
             sysmat_tmp = chnk.quadnative.buildmat(chnkr,ftmp,opdims);
         end
     else


### PR DESCRIPTION
Chunkermat would always raise an error when called with quad=native.