### PR TITLE
Quasiperiodic Helmholtz kernels

### DIFF
--- a/chunkie/+chnk/+helm2dquas/Sn.m
+++ b/chunkie/+chnk/+helm2dquas/Sn.m
@@ -1,0 +1,34 @@
+function S = Sn(n,zk,d,kappa,alpha,a,M,l)
+%CHNK.HELMQUAS.SN precompute lattice sum integrals 
+% i.e. local coefficients for the representation
+%   G_far(x,y) := sum_|n|>l i/4 H_0^{(1)}(zk |x- n d e_1-y|) 
+%                   exp(i kapppa d n)
+%              = sum_n=0^inf Sn J_n(zk |x-y|) cos(n arg(x-y))
+% 
+% (see Yasumoto and K. Yoshitomi (1999)) 
+%
+% computes the nth order lattice sum using trapezoid rule on the interval 
+%   [0,a] with M points
+%
+% quasi periodic parameters:
+%   d - period
+%   kappa - quasiperiodic parameter
+%   alpha - exp(1i*d*kappa), chosen so that u(x+d) = alpha * u(x)
+
+if nargin < 8, l = 2; end
+taus = linspace(0,a,M)*(1-1i);
+
+sq_taus = sqrt(1-taus.^2);
+
+Gp = exp(n*log(taus - 1i*sq_taus) +l*1i*zk*d*sq_taus);
+Gm = exp(n*log(-taus - 1i*sq_taus) +l*1i*zk*d*sq_taus);
+
+Fp = 1./(sq_taus.*(1-exp(1i*zk*d.*(sq_taus-kappa*d./zk/d))));
+Fm = 1./(sq_taus.*(1-exp(1i*zk*d.*(sq_taus+kappa*d./zk/d))));
+
+S_p = sum((Gp+Gm).*Fp,2)-(Gp(:,1)+Gm(:,1)).*Fp(:,1)/2;
+S_m = sum((Gp+Gm).*Fm,2)-(Gp(:,1)+Gm(:,1)).*Fm(:,1)/2;
+
+S = -1i*exp(1i*pi/4)*sqrt(2)/pi*((-1).^n.*alpha^(-l).*S_p+alpha^(l)*S_m)*a/(M-1);
+
+end

--- a/chunkie/+chnk/+helm2dquas/green.m
+++ b/chunkie/+chnk/+helm2dquas/green.m
@@ -1,0 +1,189 @@
+function [val,grad,hess] = green(src,targ,zk,kappa,d,Sn,l)
+%CHNK.HELM2DQUAS.GREEN evaluate the quasiperiodic helmholtz green's function
+% for the given sources and targets
+%
+% Input:
+%   zk - wavenumber
+%   kappa - quasiperiodic parameter
+%   d - period
+%   Sn - precomputed lattice sum integrals (see chnk.helm2dquas.Sn)
+%
+% see also CHNK.HELM2DQUAS.KERN
+[~,nsrc] = size(src);
+[~,ntarg] = size(targ);
+
+
+xs = repmat(src(1,:),ntarg,1);
+ys = repmat(src(2,:),ntarg,1);
+
+xt = repmat(targ(1,:).',1,nsrc);
+yt = repmat(targ(2,:).',1,nsrc);
+
+rx = xt-xs;
+ry = yt-ys;
+
+nx = fix(rx/l/d);
+rx = rx - nx*l*d;
+
+
+rx2 = rx.*rx;
+ry2 = ry.*ry;
+
+r2 = rx2+ry2;
+
+r = sqrt(r2);
+
+rx = rx(:);
+ry = ry(:);
+r = r(:);
+
+npt = size(r,1);
+
+ythresh = d/2;
+% ythresh = d/10;
+iclose = abs(ry) < ythresh;
+ifar = ~iclose;
+
+rxfar = rx(ifar);
+ryfar = ry(ifar);
+
+rxclose = rx(iclose);
+ryclose = ry(iclose);
+rclose = r(iclose);
+
+
+val = zeros(npt,1);
+if nargout > 1
+grad = zeros(npt,2);
+end
+if nargout > 2
+hess = zeros(npt,3);
+end
+
+
+tol = 1e-10;
+Lbd = sqrt((log(tol))^2/real(ythresh)^2 + real(zk)^2);
+
+if ~isempty(ryfar)
+M = ceil(Lbd*d/(2*pi));
+ms = (-M:M);
+xi_m = kappa + 2*pi/d*ms;
+
+% beta = sqrt((xi_m.^2-zk^2));
+beta = sqrt(1i*(xi_m-zk)).*sqrt(-1i*(xi_m+zk));
+
+fhat = exp(-beta.*sqrt(ryfar.^2))./beta.*exp(1i*xi_m.*rxfar)/2;
+val(ifar,:) = sum(fhat,2)/(d);
+if nargout > 1
+gx = sum(1i*xi_m.*fhat,2)/d;
+gy = sum(-beta.*(sqrt(ryfar.^2)./ryfar).*fhat,2)/d;
+grad(ifar,:) =[gx,gy];
+end
+
+if nargout >2
+hxx = sum(-xi_m.^2.*fhat,2)/d;
+hxy = sum(-1i*xi_m.*beta.*(sqrt(ryfar.^2)./ryfar).*fhat,2)/d;
+hyy = sum((beta.*(sqrt(ryfar.^2)./ryfar)).^2.*fhat,2)/d;
+hess(ifar,:) = [hxx,hxy,hyy];
+end
+
+
+end
+
+alpha = (exp(1i*kappa*d));
+
+val_near=0;
+grad_near = [0,0];
+hess_near = [0,0,0];
+if ~isempty(rxclose)
+    for i = -l:l
+        rxi = rxclose - i*d;
+        if nargout>2
+        [vali,gradi,hessi] = chnk.helm2d.green(zk,[0;0],[rxi.';ryclose.']);
+        gradi = reshape(gradi,[],2);
+        hessi = reshape(hessi,[],3);
+        val_near = val_near + vali*alpha^i;
+        grad_near = grad_near + gradi*alpha^i;
+        hess_near = hess_near + hessi*alpha^i;
+        elseif nargout > 1
+        [vali,gradi] = chnk.helm2d.green(zk,[0;0],[rxi.';ryclose.']);
+        gradi = reshape(gradi,[],2);
+        val_near = val_near + vali*alpha^i;
+        grad_near = grad_near + gradi*alpha^i;
+        else
+        vali = chnk.helm2d.green(zk,[0;0],[rxi.';ryclose.']);
+        val_near = val_near + vali*alpha^i;
+        end
+    end
+    
+    Sn = Sn.';
+    N = length(Sn)-1;
+    ns = (0:N);
+    Js = zeros(length(rclose),N+3);
+    for i = 1:length(rclose)
+    Js(i,:) = besselj((0:N+2),zk*rclose(i));
+    end
+    eip = (rxclose+1i*ryclose)./rclose;
+    cs = (eip.^ns+eip.^(-ns))/2;
+    
+    
+    val_far = 0.25*1i*Js(:,1)*Sn(1) + 0.5*1i*sum(Sn(2:end).*Js(:,2:end-2).*cs(:,2:end),2);
+    val(iclose) = val_near+val_far;
+    
+    
+    
+    
+    if nargout >1
+        DJs = [-Js(:,2),.5*(Js(:,1:end-3)-Js(:,3:end-1))]*zk;
+        ss = (eip.^ns-eip.^(-ns))/2i;
+            
+        grad_far_p = 0.25*1i*DJs(:,1)*Sn(1) + 0.5*1i*sum(Sn(2:end).*DJs(:,2:end).*cs(:,2:end),2);
+        grad_far_t = (0.5*1i*sum(-(1:N).*Sn(2:end).*Js(:,2:end-2).*ss(:,2:end),2))./rclose;
+        
+        grad_far = [cs(:,2).*grad_far_p - ss(:,2).*grad_far_t, ss(:,2).*grad_far_p + cs(:,2).*grad_far_t];
+    
+        grad(iclose,:) = grad_near + grad_far; 
+    end
+    if nargout > 2
+        DDJs = [.5*(Js(:,3)-Js(:,1)),.25*(Js(:,4)-3*Js(:,2)),.25*(Js(:,1:end-4)-2*Js(:,3:end-2)+Js(:,5:end))]*zk^2;
+
+
+        tmp_n = rclose.^(-4).*(-ns.*ryclose.*Js(:,1:end-2).*(ns.*ryclose.*cs+2*rxclose.*ss)+ ...
+            rclose.*ryclose.*(ryclose.*cs + 2*ns.*rxclose.*ss).*DJs+ ...
+            rclose.^2.*rxclose.^2.*cs.*DDJs);
+        hess_far_xx = 0.25*1i*tmp_n(:,1)*Sn(1)+.5*1i*sum(Sn(2:end).*tmp_n(:,2:end),2);
+
+        tmp_n = ns.*Js(:,1:end-2).*(ns.*rxclose.*ryclose.*cs+(rxclose.^2-ryclose.^2).*ss).*rclose.^(-4) ...
+            +rclose.^(-3).*(-(rxclose.*ryclose.*cs+ns.*(rxclose.^2-ryclose.^2).*ss).*DJs+...
+            rclose.*rxclose.*ryclose.*cs.*DDJs);
+
+
+        hess_far_xy = 0.25*1i*tmp_n(:,1)*Sn(1)+.5*1i*sum(Sn(2:end).*tmp_n(:,2:end),2);
+
+        tmp_n = rclose.^(-4).*(-ns.*rxclose.*Js(:,1:end-2).*(ns.*rxclose.*cs-2*ryclose.*ss)+ ...
+            rclose.*rxclose.*(rxclose.*cs - 2*ns.*ryclose.*ss).*DJs+ ...
+            rclose.^2.*ryclose.^2.*cs.*DDJs);
+        hess_far_yy = 0.25*1i*tmp_n(:,1)*Sn(1)+.5*1i*sum(Sn(2:end).*tmp_n(:,2:end),2);
+
+
+
+        hess_far = [hess_far_xx, hess_far_xy, hess_far_yy];
+
+
+        hess(iclose,:) = hess_near + hess_far;
+    end
+end
+
+quasi_phase = exp(1i*kappa*nx(:)*l*d);
+
+val = reshape(quasi_phase.*val,ntarg,nsrc);
+if nargout>1
+grad = reshape(quasi_phase.*grad,ntarg,nsrc,2);
+end
+if nargout>2
+hess = reshape(quasi_phase.*hess,ntarg,nsrc,3);
+end
+% end
+
+end
+

--- a/chunkie/+chnk/+helm2dquas/green.m
+++ b/chunkie/+chnk/+helm2dquas/green.m
@@ -1,4 +1,4 @@
-function [val,grad,hess] = green(src,targ,zk,kappa,d,Sn,l)
+function [val,grad,hess] = green(src,targ,zk,kappa,d,sn,l)
 %CHNK.HELM2DQUAS.GREEN evaluate the quasiperiodic helmholtz green's function
 % for the given sources and targets
 %
@@ -6,7 +6,8 @@ function [val,grad,hess] = green(src,targ,zk,kappa,d,Sn,l)
 %   zk - wavenumber
 %   kappa - quasiperiodic parameter
 %   d - period
-%   Sn - precomputed lattice sum integrals (see chnk.helm2dquas.Sn)
+%   sn - precomputed lattice sum integrals 
+%       (see chnk.helm2dquas.latticecoefs)
 %
 % see also CHNK.HELM2DQUAS.KERN
 [~,nsrc] = size(src);
@@ -116,8 +117,8 @@ if ~isempty(rxclose)
         end
     end
     
-    Sn = Sn.';
-    N = length(Sn)-1;
+    sn = sn.';
+    N = length(sn)-1;
     ns = (0:N);
     Js = zeros(length(rclose),N+3);
     for i = 1:length(rclose)
@@ -127,7 +128,7 @@ if ~isempty(rxclose)
     cs = (eip.^ns+eip.^(-ns))/2;
     
     
-    val_far = 0.25*1i*Js(:,1)*Sn(1) + 0.5*1i*sum(Sn(2:end).*Js(:,2:end-2).*cs(:,2:end),2);
+    val_far = 0.25*1i*Js(:,1)*sn(1) + 0.5*1i*sum(sn(2:end).*Js(:,2:end-2).*cs(:,2:end),2);
     val(iclose) = val_near+val_far;
     
     
@@ -137,8 +138,8 @@ if ~isempty(rxclose)
         DJs = [-Js(:,2),.5*(Js(:,1:end-3)-Js(:,3:end-1))]*zk;
         ss = (eip.^ns-eip.^(-ns))/2i;
             
-        grad_far_p = 0.25*1i*DJs(:,1)*Sn(1) + 0.5*1i*sum(Sn(2:end).*DJs(:,2:end).*cs(:,2:end),2);
-        grad_far_t = (0.5*1i*sum(-(1:N).*Sn(2:end).*Js(:,2:end-2).*ss(:,2:end),2))./rclose;
+        grad_far_p = 0.25*1i*DJs(:,1)*sn(1) + 0.5*1i*sum(sn(2:end).*DJs(:,2:end).*cs(:,2:end),2);
+        grad_far_t = (0.5*1i*sum(-(1:N).*sn(2:end).*Js(:,2:end-2).*ss(:,2:end),2))./rclose;
         
         grad_far = [cs(:,2).*grad_far_p - ss(:,2).*grad_far_t, ss(:,2).*grad_far_p + cs(:,2).*grad_far_t];
     
@@ -151,19 +152,19 @@ if ~isempty(rxclose)
         tmp_n = rclose.^(-4).*(-ns.*ryclose.*Js(:,1:end-2).*(ns.*ryclose.*cs+2*rxclose.*ss)+ ...
             rclose.*ryclose.*(ryclose.*cs + 2*ns.*rxclose.*ss).*DJs+ ...
             rclose.^2.*rxclose.^2.*cs.*DDJs);
-        hess_far_xx = 0.25*1i*tmp_n(:,1)*Sn(1)+.5*1i*sum(Sn(2:end).*tmp_n(:,2:end),2);
+        hess_far_xx = 0.25*1i*tmp_n(:,1)*sn(1)+.5*1i*sum(sn(2:end).*tmp_n(:,2:end),2);
 
         tmp_n = ns.*Js(:,1:end-2).*(ns.*rxclose.*ryclose.*cs+(rxclose.^2-ryclose.^2).*ss).*rclose.^(-4) ...
             +rclose.^(-3).*(-(rxclose.*ryclose.*cs+ns.*(rxclose.^2-ryclose.^2).*ss).*DJs+...
             rclose.*rxclose.*ryclose.*cs.*DDJs);
 
 
-        hess_far_xy = 0.25*1i*tmp_n(:,1)*Sn(1)+.5*1i*sum(Sn(2:end).*tmp_n(:,2:end),2);
+        hess_far_xy = 0.25*1i*tmp_n(:,1)*sn(1)+.5*1i*sum(sn(2:end).*tmp_n(:,2:end),2);
 
         tmp_n = rclose.^(-4).*(-ns.*rxclose.*Js(:,1:end-2).*(ns.*rxclose.*cs-2*ryclose.*ss)+ ...
             rclose.*rxclose.*(rxclose.*cs - 2*ns.*ryclose.*ss).*DJs+ ...
             rclose.^2.*ryclose.^2.*cs.*DDJs);
-        hess_far_yy = 0.25*1i*tmp_n(:,1)*Sn(1)+.5*1i*sum(Sn(2:end).*tmp_n(:,2:end),2);
+        hess_far_yy = 0.25*1i*tmp_n(:,1)*sn(1)+.5*1i*sum(sn(2:end).*tmp_n(:,2:end),2);
 
 
 

--- a/chunkie/+chnk/+helm2dquas/kern.m
+++ b/chunkie/+chnk/+helm2dquas/kern.m
@@ -62,7 +62,8 @@ function submat=kern(zk,srcinfo,targinfo,type,quas_param,varargin)
 %       quas_param.kappa - phase difference
 %       quas_param.d - period
 %       quas_param.l - radius excluded from local quasiperiodic farfield
-%       quas_param.Sn - precomputed lattice sum integrals, see chnk.helm2dquas.Sn
+%       quas_param.sn - precomputed lattice sum integrals, see 
+%               chnk.helm2dquas.latticecoefs
 %
 %   varargin{1} - coef: length 2 array in the combined layer 
 %                 formula, 2x2 matrix for all kernels
@@ -82,7 +83,7 @@ targ = targinfo.r;
 kappa = quas_param.kappa;
 d = quas_param.d;
 l = quas_param.l;
-Sn = quas_param.Sn;
+sn = quas_param.sn;
 
 
 [~,ns] = size(src);
@@ -91,7 +92,7 @@ Sn = quas_param.Sn;
 % double layer
 if strcmpi(type,'d')
   srcnorm = srcinfo.n;
-  [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
   nx = repmat(srcnorm(1,:),nt,1);
   ny = repmat(srcnorm(2,:),nt,1);
   submat = -(grad(:,:,1).*nx + grad(:,:,2).*ny);
@@ -100,7 +101,7 @@ end
 % normal derivative of single layer
 if strcmpi(type,'sprime')
   targnorm = targinfo.n;
-  [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
   nx = repmat((targnorm(1,:)).',1,ns);
   ny = repmat((targnorm(2,:)).',1,ns);
 
@@ -109,21 +110,21 @@ end
 
 % x derivative of single layer
 if strcmpi(type,'sx')
-  [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
 
   submat = (grad(:,:,1));
 end
 
 % single later
 if strcmpi(type,'s')
-  submat = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  submat = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
 end
 
 % normal derivative of double layer
 if strcmpi(type,'dprime')
   targnorm = targinfo.n;
   srcnorm = srcinfo.n;
-  [~,~,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [~,~,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
   nxsrc = repmat(srcnorm(1,:),nt,1);
   nysrc = repmat(srcnorm(2,:),nt,1);
   nxtarg = repmat((targnorm(1,:)).',1,ns);
@@ -134,13 +135,13 @@ end
 
 % gradient of single layer
 if strcmpi(type,'sgrad')
-    [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+    [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
     submat = reshape(permute(grad,[3,1,2]),2*nt,ns);
 end
 
 % gradient of double layer
 if strcmpi(type,'dgrad')
-    [~,~,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+    [~,~,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
     submat = -(hess(:,:,1:2).*srcinfo.n(1,:)+hess(:,:,2:3).*srcinfo.n(2,:));
     submat = reshape(permute(submat,[3,1,2]),2*nt,ns);
 end
@@ -151,7 +152,7 @@ if strcmpi(type,'c')
   srcnorm = srcinfo.n;
   coef = ones(2,1);
   if(nargin == 6); coef = varargin{1}; end
-  [submats,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [submats,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
   nx = repmat(srcnorm(1,:),nt,1);
   ny = repmat(srcnorm(2,:),nt,1);
   submatd = -(grad(:,:,1).*nx + grad(:,:,2).*ny);
@@ -166,7 +167,7 @@ if strcmpi(type,'cprime')
   srcnorm = srcinfo.n;
 
   % Get gradient and hessian info
-  [~,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [~,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
 
   nxsrc = repmat(srcnorm(1,:),nt,1);
   nysrc = repmat(srcnorm(2,:),nt,1);
@@ -191,7 +192,7 @@ if strcmpi(type,'c2trans')
   srcnorm = srcinfo.n;
 
   % Get gradient and hessian info
-  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
 
   nxsrc = repmat(srcnorm(1,:),nt,1);
   nysrc = repmat(srcnorm(2,:),nt,1);
@@ -218,7 +219,7 @@ end
 if strcmpi(type,'cgrad')
     coef = ones(2,1);
     if(nargin == 6); coef = varargin{1}; end
-    [~,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+    [~,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
 
     submats = reshape(permute(grad,[3,1,2]),2*nt,ns);
 
@@ -239,7 +240,7 @@ if strcmpi(type,'all')
   submat = zeros(2*nt,2*ns);
 
   % Get gradient and hessian info
-  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
 
   nxsrc = repmat(srcnorm(1,:),nt,1);
   nysrc = repmat(srcnorm(2,:),nt,1);
@@ -266,7 +267,7 @@ if strcmpi(type,'trans_rep')
   coef = ones(2,1);
   if(nargin == 6); coef = varargin{1}; end;
   srcnorm = srcinfo.n;
-  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
   nx = repmat(srcnorm(1,:),nt,1);
   ny = repmat(srcnorm(2,:),nt,1);
   submatd = -(grad(:,:,1).*nx + grad(:,:,2).*ny);
@@ -286,7 +287,7 @@ if strcmpi(type,'trans_rep_prime')
   submat = zeros(nt,ns);
 
   % Get gradient and hessian info
-  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
 
   nxsrc = repmat(srcnorm(1,:),nt,1);
   nysrc = repmat(srcnorm(2,:),nt,1);
@@ -313,7 +314,7 @@ if strcmpi(type,'trans_rep_grad')
   
   % submat = zeros(nt,ns,6);
   % S
-  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,sn,l);
 
   nxsrc = repmat(srcnorm(1,:),nt,1);
   nysrc = repmat(srcnorm(2,:),nt,1);

--- a/chunkie/+chnk/+helm2dquas/kern.m
+++ b/chunkie/+chnk/+helm2dquas/kern.m
@@ -1,0 +1,337 @@
+function submat=kern(zk,srcinfo,targinfo,type,quas_param,varargin)
+%CHNK.HELM2DQUAS.KERN quasi-periodic Helmholtz layer potential kernels in 2D
+% 
+% Syntax: submat = chnk.helm2dquas.kern(zk,srcinfo,targinfo,type,quas_param,varargin)
+%
+% Let x be targets and y be sources for these formulas, with
+% n_x and n_y the corresponding unit normals at those points
+% (if defined). 
+%  
+% Kernels based on the quasi periodic green's function satisfying 
+%       G(x+d e_1,y) = G(x,y) exp(i kapppa d),
+%  which is given by
+%       G(x,y) = sum_{n=-inf}^inf i/4 H_0^{(1)}(zk |x- n d e_1-y|) 
+%                   exp(i kapppa d n)
+%
+% NOTE: The quasiperiodic green's has extra singularities at periodic 
+% copies of the source, which might cause quadrature errors.
+%
+% NOTE: This will be singular if kappa = +- pi/d
+%
+% D(x,y) = \nabla_{n_y} G(x,y)
+% S(x,y) = G(x,y)
+% S'(x,y) = \nabla_{n_x} G(x,y)
+% D'(x,y) = \nabla_{n_x} \nabla_{n_y} G(x,y)
+%
+% Input:
+%   zk - complex number, Helmholtz wave number
+%   srcinfo - description of sources in ptinfo struct format, i.e.
+%                ptinfo.r - positions (2,:) array
+%                ptinfo.d - first derivative in underlying
+%                     parameterization (2,:)
+%                ptinfo.d2 - second derivative in underlying
+%                     parameterization (2,:)
+%   targinfo - description of targets in ptinfo struct format,
+%                if info not relevant (d/d2) it doesn't need to
+%                be provided. sprime requires tangent info in
+%                targinfo.d
+%   type - string, determines kernel type
+%                type == 'd', double layer kernel D
+%                type == 's', single layer kernel S
+%                type == 'sprime', normal derivative of single
+%                      layer S'
+%                type == 'dprime', normal derivative of double layer D'
+%                type == 'c', combined layer kernel coef(1) D + coef(2) S
+%                type == 'all', returns all four layer potentials, 
+%                       [coef(1,1)*D coef(1,2)*S; coef(2,1)*D' coef(2,2)*S']
+%                type == 'c2trans' returns the combined field, and the 
+%                          normal derivative of the combined field
+%                        [coef(1)*D + coef(2)*S; coef(1)*D' + coef(2)*S']
+%                type == 'trans_rep' returns the potential corresponding
+%                           to the transmission representation
+%                        [coef(1)*D coef(2)*S]
+%                type == 'trans_rep_prime' returns the normal derivative
+%                          corresponding to the transmission representation
+%                        [coef(1)*D' coef(2)*S']
+%                type == 'trans_rep_grad' returns the gradient corresponding
+%                         to the transmission representation
+%                        [coef(1)*d_x D coef(2)*d_x S;
+%                         coef(1)*d_y D coef(2)*d_y S]
+% 
+%   quas_param - struct with quasiperiodic parameters,
+%       quas_param.kappa - phase difference
+%       quas_param.d - period
+%       quas_param.l - radius excluded from local quasiperiodic farfield
+%       quas_param.Sn - precomputed lattice sum integrals, see chnk.helm2dquas.Sn
+%
+%   varargin{1} - coef: length 2 array in the combined layer 
+%                 formula, 2x2 matrix for all kernels
+%                 otherwise does nothing
+%
+% Output:
+%   submat - the evaluation of the selected kernel for the
+%            provided sources and targets. the number of
+%            rows equals the number of targets and the
+%            number of columns equals the number of sources  
+%
+% see also CHNK.HELM2DQUAS.GREEN
+
+src = srcinfo.r;
+targ = targinfo.r;
+
+kappa = quas_param.kappa;
+d = quas_param.d;
+l = quas_param.l;
+Sn = quas_param.Sn;
+
+
+[~,ns] = size(src);
+[~,nt] = size(targ);
+
+% double layer
+if strcmpi(type,'d')
+  srcnorm = srcinfo.n;
+  [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  nx = repmat(srcnorm(1,:),nt,1);
+  ny = repmat(srcnorm(2,:),nt,1);
+  submat = -(grad(:,:,1).*nx + grad(:,:,2).*ny);
+end
+
+% normal derivative of single layer
+if strcmpi(type,'sprime')
+  targnorm = targinfo.n;
+  [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  nx = repmat((targnorm(1,:)).',1,ns);
+  ny = repmat((targnorm(2,:)).',1,ns);
+
+  submat = (grad(:,:,1).*nx + grad(:,:,2).*ny);
+end
+
+% x derivative of single layer
+if strcmpi(type,'sx')
+  [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+
+  submat = (grad(:,:,1));
+end
+
+% single later
+if strcmpi(type,'s')
+  submat = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+end
+
+% normal derivative of double layer
+if strcmpi(type,'dprime')
+  targnorm = targinfo.n;
+  srcnorm = srcinfo.n;
+  [~,~,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  nxsrc = repmat(srcnorm(1,:),nt,1);
+  nysrc = repmat(srcnorm(2,:),nt,1);
+  nxtarg = repmat((targnorm(1,:)).',1,ns);
+  nytarg = repmat((targnorm(2,:)).',1,ns);
+  submat = -(hess(:,:,1).*nxsrc.*nxtarg + hess(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
+      + hess(:,:,3).*nysrc.*nytarg);
+end
+
+% gradient of single layer
+if strcmpi(type,'sgrad')
+    [~,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+    submat = reshape(permute(grad,[3,1,2]),2*nt,ns);
+end
+
+% gradient of double layer
+if strcmpi(type,'dgrad')
+    [~,~,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+    submat = -(hess(:,:,1:2).*srcinfo.n(1,:)+hess(:,:,2:3).*srcinfo.n(2,:));
+    submat = reshape(permute(submat,[3,1,2]),2*nt,ns);
+end
+
+
+% Combined field 
+if strcmpi(type,'c')
+  srcnorm = srcinfo.n;
+  coef = ones(2,1);
+  if(nargin == 6); coef = varargin{1}; end
+  [submats,grad] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  nx = repmat(srcnorm(1,:),nt,1);
+  ny = repmat(srcnorm(2,:),nt,1);
+  submatd = -(grad(:,:,1).*nx + grad(:,:,2).*ny);
+  submat = coef(1)*submatd + coef(2)*submats;
+end
+
+% normal derivative of combined field
+if strcmpi(type,'cprime')
+  coef = ones(2,1);
+  if(nargin == 6); coef = varargin{1}; end
+  targnorm = targinfo.n;
+  srcnorm = srcinfo.n;
+
+  % Get gradient and hessian info
+  [~,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+
+  nxsrc = repmat(srcnorm(1,:),nt,1);
+  nysrc = repmat(srcnorm(2,:),nt,1);
+  nxtarg = repmat((targnorm(1,:)).',1,ns);
+  nytarg = repmat((targnorm(2,:)).',1,ns);
+
+  % D'
+  submatdp = -(hess(:,:,1).*nxsrc.*nxtarg ...
+      + hess(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
+      + hess(:,:,3).*nysrc.*nytarg);
+  % S'
+  submatsp = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
+
+  submat = coef(1)*submatdp + coef(2)*submatsp;
+end
+
+% Dirichlet and neumann data corresponding to combined field
+if strcmpi(type,'c2trans') 
+  coef = ones(2,1);
+  if(nargin == 6); coef = varargin{1}; end
+  targnorm = targinfo.n;
+  srcnorm = srcinfo.n;
+
+  % Get gradient and hessian info
+  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+
+  nxsrc = repmat(srcnorm(1,:),nt,1);
+  nysrc = repmat(srcnorm(2,:),nt,1);
+  nxtarg = repmat((targnorm(1,:)).',1,ns);
+  nytarg = repmat((targnorm(2,:)).',1,ns);
+
+  % D'
+  submatdp = -(hess(:,:,1).*nxsrc.*nxtarg ...
+      + hess(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
+      + hess(:,:,3).*nysrc.*nytarg);
+  % S'
+  submatsp = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
+  % D
+  submatd = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
+
+  submat = zeros(2*nt,ns);
+
+  submat(1:2:2*nt,:) = coef(1)*submatd + coef(2)*submats;
+  submat(2:2:2*nt,:) = coef(1)*submatdp + coef(2)*submatsp;
+
+end
+
+% gradient of combined field
+if strcmpi(type,'cgrad')
+    coef = ones(2,1);
+    if(nargin == 6); coef = varargin{1}; end
+    [~,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+
+    submats = reshape(permute(grad,[3,1,2]),2*nt,ns);
+
+    submatd = -(hess(:,:,1:2).*srcinfo.n(1,:)+hess(:,:,2:3).*srcinfo.n(2,:));
+    submatd = reshape(permute(submatd,[3,1,2]),2*nt,ns);
+    
+    submat = coef(1)*submatd + coef(2)*submats;
+end
+  
+
+% all kernels, [c11 D, c12 S; c21 D', c22 S'] 
+if strcmpi(type,'all')
+ 
+  targnorm = targinfo.n;
+  srcnorm = srcinfo.n;
+  cc = varargin{1};
+  
+  submat = zeros(2*nt,2*ns);
+
+  % Get gradient and hessian info
+  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+
+  nxsrc = repmat(srcnorm(1,:),nt,1);
+  nysrc = repmat(srcnorm(2,:),nt,1);
+  nxtarg = repmat((targnorm(1,:)).',1,ns);
+  nytarg = repmat((targnorm(2,:)).',1,ns);
+
+  submatdp = -(hess(:,:,1).*nxsrc.*nxtarg ...
+      + hess(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
+      + hess(:,:,3).*nysrc.*nytarg);
+  % S'
+  submatsp = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
+  % D
+  submatd  = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
+  
+  
+  submat(1:2:2*nt,1:2:2*ns) = submatd*cc(1,1);
+  submat(1:2:2*nt,2:2:2*ns) = submats*cc(1,2);
+  submat(2:2:2*nt,1:2:2*ns) = submatdp*cc(2,1);
+  submat(2:2:2*nt,2:2:2*ns) = submatsp*cc(2,2);
+end
+% Dirichlet data/potential correpsonding to transmission rep
+if strcmpi(type,'trans_rep') 
+
+  coef = ones(2,1);
+  if(nargin == 6); coef = varargin{1}; end;
+  srcnorm = srcinfo.n;
+  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+  nx = repmat(srcnorm(1,:),nt,1);
+  ny = repmat(srcnorm(2,:),nt,1);
+  submatd = -(grad(:,:,1).*nx + grad(:,:,2).*ny);
+
+  submat = zeros(1*nt,2*ns);
+  submat(1:1:1*nt,1:2:2*ns) = coef(1)*submatd;
+  submat(1:1:1*nt,2:2:2*ns) = coef(2)*submats;
+end
+
+% Neumann data corresponding to transmission rep
+if strcmpi(type,'trans_rep_prime')
+  coef = ones(2,1);
+  if(nargin == 6); coef = varargin{1}; end;
+  targnorm = targinfo.n;
+  srcnorm = srcinfo.n;
+  
+  submat = zeros(nt,ns);
+
+  % Get gradient and hessian info
+  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+
+  nxsrc = repmat(srcnorm(1,:),nt,1);
+  nysrc = repmat(srcnorm(2,:),nt,1);
+  nxtarg = repmat((targnorm(1,:)).',1,ns);
+  nytarg = repmat((targnorm(2,:)).',1,ns);
+
+  % D'
+  submatdp = -(hess(:,:,1).*nxsrc.*nxtarg ...
+      + hess(:,:,2).*(nysrc.*nxtarg+nxsrc.*nytarg)...
+      + hess(:,:,3).*nysrc.*nytarg);
+  % S'
+  submatsp = (grad(:,:,1).*nxtarg + grad(:,:,2).*nytarg);
+  submat = zeros(nt,2*ns);
+  submat(1:1:1*nt,1:2:2*ns) = coef(1)*submatdp;
+  submat(1:1:1*nt,2:2:2*ns) = coef(2)*submatsp;
+end
+
+% Gradient correpsonding to transmission rep
+if strcmpi(type,'trans_rep_grad')
+  coef = ones(2,1);
+  if(nargin == 6); coef = varargin{1}; end;
+  
+  srcnorm = srcinfo.n;
+  
+  % submat = zeros(nt,ns,6);
+  % S
+  [submats,grad,hess] = chnk.helm2dquas.green(src,targ,zk,kappa,d,Sn,l);
+
+  nxsrc = repmat(srcnorm(1,:),nt,1);
+  nysrc = repmat(srcnorm(2,:),nt,1);
+  % D
+  submatd  = -(grad(:,:,1).*nxsrc + grad(:,:,2).*nysrc);
+
+  submat = zeros(2*nt,2*ns);
+  
+  submat(1:2:2*nt,1:2:2*ns) = -coef(1)*(hess(:,:,1).*nxsrc + hess(:,:,2).*nysrc);
+  submat(1:2:2*nt,2:2:2*ns) = coef(2)*grad(:,:,1);
+    
+  submat(2:2:2*nt,1:2:2*ns) = -coef(1)*(hess(:,:,2).*nxsrc + hess(:,:,3).*nysrc);
+  submat(2:2:2*nt,2:2:2*ns) = coef(2)*grad(:,:,2);
+end
+
+
+
+
+
+
+end

--- a/chunkie/+chnk/+helm2dquas/latticecoefs.m
+++ b/chunkie/+chnk/+helm2dquas/latticecoefs.m
@@ -1,5 +1,5 @@
-function S = Sn(n,zk,d,kappa,alpha,a,M,l)
-%CHNK.HELMQUAS.SN precompute lattice sum integrals 
+function S = latticecoefs(n,zk,d,kappa,alpha,a,M,l)
+%CHNK.HELMQUAS.LATTICECOEFS precompute lattice sum integrals 
 % i.e. local coefficients for the representation
 %   G_far(x,y) := sum_|n|>l i/4 H_0^{(1)}(zk |x- n d e_1-y|) 
 %                   exp(i kapppa d n)

--- a/chunkie/@kernel/helm2dquas.m
+++ b/chunkie/@kernel/helm2dquas.m
@@ -154,11 +154,6 @@ end
 
 function f = helm2dquas_s_split(zk,s,t,quas_param)
 seval = chnk.helm2dquas.kern(zk, s, t, 's',quas_param);
-
-rx = t.r(1,:).' - s.r(1,:);
-nx = fix(mean(rx/quas_param.d,"all"));
-t.r(1,:) = t.r(1,:) - nx*quas_param.d;
-
 s0eval = chnk.helm2d.kern(zk, s, t, 's');
 dist = (s.r(1,:)+1i*s.r(2,:))-(t.r(1,:)'+1i*t.r(2,:)');
 logeval = log(abs(dist));
@@ -169,11 +164,6 @@ end
 
 function f = helm2dquas_d_split(zk,s,t,quas_param)
 deval = chnk.helm2dquas.kern(zk, s, t, 'd',quas_param);
-
-rx = t.r(1,:).' - s.r(1,:);
-nx = fix(mean(rx/quas_param.d,"all"));
-t.r(1,:) = t.r(1,:) - nx*quas_param.d;
-
 d0eval = chnk.helm2d.kern(zk, s, t, 'd');
 dist = (s.r(1,:)+1i*s.r(2,:))-(t.r(1,:)'+1i*t.r(2,:)');
 logeval = log(abs(dist));
@@ -187,10 +177,6 @@ end
 function f = helm2dquas_c_split(zk,s,t,quas_param,coefs)
 seval = chnk.helm2dquas.kern(zk, s, t, 's',quas_param);
 deval = chnk.helm2dquas.kern(zk, s, t, 'd',quas_param);
-
-rx = t.r(1,:).' - s.r(1,:);
-nx = fix(mean(rx/quas_param.d,"all"));
-t.r(1,:) = t.r(1,:) - nx*quas_param.d;
 
 s0eval = chnk.helm2d.kern(zk, s, t, 's');
 d0eval = chnk.helm2d.kern(zk, s, t, 'd');

--- a/chunkie/@kernel/helm2dquas.m
+++ b/chunkie/@kernel/helm2dquas.m
@@ -26,7 +26,7 @@ function obj = helm2dquas(type, zk, kappa, d, coefs, quad_opts)
 %      COEFS(2)*KERNEL.HELM2DQUAS('sp', ZK, KAPPA, D).
 %   
 %   all versions accept quad_opts to change the parameters in the lattice
-%   sum computations. (see chnk.helm2dquas.Sn)
+%   sum computations. (see chnk.helm2dquas.latticecoefs)
 %       quad_opts.l - (2) radius of periodic copies to exclude from 
 %           lattice sum (excludes copies within l*d)
 %       quad_opts.N - (40) number of lattice sums
@@ -70,13 +70,13 @@ if nargin == 6
 end
 
 ns = (0:N).';
-Sn = chnk.helm2dquas.Sn(ns,zk,d,kappa,(exp(1i*kappa*d)),a,M,l+1);
+sn = chnk.helm2dquas.latticecoefs(ns,zk,d,kappa,(exp(1i*kappa*d)),a,M,l+1);
 
 quas_param = [];
 quas_param.kappa = kappa;
 quas_param.d = d;
 quas_param.l = l;
-quas_param.Sn = Sn;
+quas_param.sn = sn;
 
 % obj.params.kappa = kappa;
 % obj.params.d = d;

--- a/chunkie/@kernel/helm2dquas.m
+++ b/chunkie/@kernel/helm2dquas.m
@@ -154,34 +154,53 @@ end
 
 function f = helm2dquas_s_split(zk,s,t,quas_param)
 seval = chnk.helm2dquas.kern(zk, s, t, 's',quas_param);
+
+rx = t.r(1,:).' - s.r(1,:);
+nx = fix(mean(rx/quas_param.d,"all"));
+t.r(1,:) = t.r(1,:) - nx*quas_param.d;
+
+s0eval = chnk.helm2d.kern(zk, s, t, 's');
 dist = (s.r(1,:)+1i*s.r(2,:))-(t.r(1,:)'+1i*t.r(2,:)');
 logeval = log(abs(dist));
 f = cell(2,1);
-f{1} = seval + 1/(2*pi)*4*logeval.*imag(seval);
-f{2} = 4*imag(seval);
+f{1} = seval + 1/(2*pi)*4*logeval.*imag(s0eval);
+f{2} = 4*imag(s0eval);
 end
 
 function f = helm2dquas_d_split(zk,s,t,quas_param)
 deval = chnk.helm2dquas.kern(zk, s, t, 'd',quas_param);
+
+rx = t.r(1,:).' - s.r(1,:);
+nx = fix(mean(rx/quas_param.d,"all"));
+t.r(1,:) = t.r(1,:) - nx*quas_param.d;
+
+d0eval = chnk.helm2d.kern(zk, s, t, 'd');
 dist = (s.r(1,:)+1i*s.r(2,:))-(t.r(1,:)'+1i*t.r(2,:)');
 logeval = log(abs(dist));
 cauchyeval = (s.n(1,:)+1i*s.n(2,:))./(dist);
 f = cell(3, 1);
-f{1} = deval + 1/(2*pi)*4*logeval.*imag(deval) + 1/(2*pi)*real(cauchyeval);
-f{2} = 4*imag(deval);
+f{1} = deval + 1/(2*pi)*4*logeval.*imag(d0eval) + 1/(2*pi)*real(cauchyeval);
+f{2} = 4*imag(d0eval);
 f{3} = ones(size(t.r,2),size(s.r,2));
 end
 
 function f = helm2dquas_c_split(zk,s,t,quas_param,coefs)
 seval = chnk.helm2dquas.kern(zk, s, t, 's',quas_param);
 deval = chnk.helm2dquas.kern(zk, s, t, 'd',quas_param);
+
+rx = t.r(1,:).' - s.r(1,:);
+nx = fix(mean(rx/quas_param.d,"all"));
+t.r(1,:) = t.r(1,:) - nx*quas_param.d;
+
+s0eval = chnk.helm2d.kern(zk, s, t, 's');
+d0eval = chnk.helm2d.kern(zk, s, t, 'd');
 dist = (s.r(1,:)+1i*s.r(2,:))-(t.r(1,:)'+1i*t.r(2,:)');
 logeval = log(abs(dist));
 cauchyeval = (s.n(1,:)+1i*s.n(2,:))./(dist);
 f = cell(3, 1);
-f{1} = coefs(1) * (deval + 2/pi*logeval.*imag(deval) + 1/(2*pi)*real(cauchyeval)) + ...
-       coefs(2) * (seval + 2/pi*logeval.*imag(seval));
-f{2} = coefs(1) * (4*imag(deval)) + coefs(2) * (4*imag(seval));
+f{1} = coefs(1) * (deval + 2/pi*logeval.*imag(d0eval) + 1/(2*pi)*real(cauchyeval)) + ...
+       coefs(2) * (seval + 2/pi*logeval.*imag(s0eval));
+f{2} = coefs(1) * (4*imag(d0eval)) + coefs(2) * (4*imag(s0eval));
 f{3} = coefs(1)*ones(size(t.r,2),size(s.r,2));
 end
 

--- a/chunkie/@kernel/helm2dquas.m
+++ b/chunkie/@kernel/helm2dquas.m
@@ -1,0 +1,187 @@
+function obj = helm2dquas(type, zk, kappa, d, coefs, quad_opts)
+%KERNEL.HELM2DQUAS   Construct the quasi periodic Helmholtz kernel.
+%   KERNEL.HELM2DQUAS('s', ZK, KAPPA, D) or 
+%   KERNEL.HELM2DQUAS('single', ZK, KAPPA, D) constructs the
+%   single-layer quasiperiodic Helmholtz kernel with wavenumber ZK with 
+%   period D and quasiperiodic factor kappa.
+%
+%   KERNEL.HELM2DQUAS('d', ZK, KAPPA, D) or 
+%   KERNEL.HELM2DQUAS('double', ZK, KAPPA, D) constructs the
+%   double-layer quasiperiodic Helmholtz kernel.
+%
+%   KERNEL.HELM2DQUAS('sp', ZK, KAPPA, D) or 
+%   KERNEL.HELM2DQUAS('sprime', ZK, KAPPA, D) constructs the
+%   derivative of the single-layer Helmholtz kernel.
+%
+%   KERNEL.HELM2DQUAS('c', ZK, KAPPA, D, COEFS) or
+%   KERNEL.HELM2DQUAS('combined', ZK, KAPPA, D, COEFS)
+%   constructs the combined-layer Helmholtz kernel with
+%   parameter ETA, i.e., COEFS(1)*KERNEL.HELM2DQUAS('d', ZK) + 
+%       COEFS(2)*KERNEL.HELM2DQUAS('s', ZK).
+%
+%   KERNEL.HELM2DQUAS('cp', ZK, KAPPA, D, COEFS) or 
+%   KERNEL.HELM2DQUAS('combined', ZK, KAPPA, D, COEFS)
+%   constructs the derivative of the combined-layer Helmholtz kernel with 
+%   parameter ETA, i.e., COEFS(1)*KERNEL.HELM2DQUAS('dp', ZK, KAPPA, D) + 
+%      COEFS(2)*KERNEL.HELM2DQUAS('sp', ZK, KAPPA, D).
+%   
+%   all versions accept quad_opts to change the parameters in the lattice
+%   sum computations. (see chnk.helm2dquas.Sn)
+%       quad_opts.l - (2) radius of periodic copies to exclude from 
+%           lattice sum (excludes copies within l*d)
+%       quad_opts.N - (40) number of lattice sums
+%       quad_opts.m - (1e4) number of trapezoid rule quadrature nodes
+%       quad_opts.a - (a) length of trpezoid quadrature rule
+%   
+% See also CHNK.HELM2DQUAS.KERN.
+
+% author: Tristan Goodwill
+  
+if ( nargin < 1 )
+    error('Missing Helmholtz kernel type.');
+end
+
+if ( nargin < 2 )
+    error('Missing Helmholtz wavenumber.');
+end
+
+obj = kernel();
+obj.name = 'quasiperiodic helmholtz';
+obj.params.zk = zk;
+obj.opdims = [1 1];
+
+
+% lattice sum parameters
+l=2; N = 40; a = 15; M = 1e4;
+
+if nargin == 6
+    if isefield(quad_opts,'l')
+        l = quad_opts.l;
+    end
+    if isfield(quad_opts,'N')
+        N = quad_opts.N;
+    end
+    if isfield(quad_opts,'M')
+        M = quad_opts.M;
+    end
+    if isfield(quad_opts,'a')
+        a = quad_opts.a;
+    end
+end
+
+ns = (0:N).';
+Sn = chnk.helm2dquas.Sn(ns,zk,d,kappa,(exp(1i*kappa*d)),a,M,l+1);
+
+quas_param = [];
+quas_param.kappa = kappa;
+quas_param.d = d;
+quas_param.l = l;
+quas_param.Sn = Sn;
+
+% obj.params.kappa = kappa;
+% obj.params.d = d;
+% obj.params.l = l;
+% obj.params.Sn = Sn;
+
+obj.params.quas_param = quas_param;
+
+switch lower(type)
+
+    case {'s', 'single'}
+        obj.type = 's';
+        obj.eval = @(s,t) chnk.helm2dquas.kern(zk, s, t, 's',quas_param);
+        obj.fmm = [];
+        obj.sing = 'log';
+        obj.splitinfo = [];
+        obj.splitinfo.type = {[0 0 0 0],[1 0 0 0]};
+        obj.splitinfo.action = {'r','r'};
+        obj.splitinfo.functions = @(s,t) helm2dquas_s_split(zk,s,t,quas_param);
+
+    case {'d', 'double'}
+        obj.type = 'd';
+        obj.eval = @(s,t) chnk.helm2dquas.kern(zk, s, t, 'd',quas_param);
+        obj.fmm = [];
+        obj.sing = 'log';
+        obj.splitinfo = [];
+        obj.splitinfo.type = {[0 0 0 0],[1 0 0 0],[0 0 -1 0]};
+        obj.splitinfo.action = {'r','r','r'};
+        obj.splitinfo.functions = @(s,t) helm2dquas_d_split(zk,s,t,quas_param);
+
+    case {'sp', 'sprime'}
+        obj.type = 'sp';
+        obj.eval = @(s,t) chnk.helm2dquas.kern(zk, s, t, 'sprime',quas_param);
+        obj.fmm = [];
+        obj.sing = 'log';
+
+    case {'dp', 'dprime'}
+        obj.type = 'dp';
+        obj.eval = @(s,t) chnk.helm2dquas.kern(zk, s, t, 'dprime',quas_param);
+        obj.fmm = [];
+        obj.sing = 'hs';
+
+    case {'c', 'combined'}
+        if ( nargin < 3 )
+            warning('Missing combined layer coefficients. Defaulting to [1,1i].');
+            coefs = [1,1i];
+        end
+        obj.type = 'c';
+        obj.params.coefs = coefs;
+        obj.eval = @(s,t) chnk.helm2dquas.kern(zk, s, t, 'c',quas_param, coefs);
+        obj.fmm = [];
+        obj.sing = 'log';
+        obj.splitinfo = [];
+        obj.splitinfo.type = {[0 0 0 0],[1 0 0 0],[0 0 -1 0]};
+        obj.splitinfo.action = {'r','r','r'};
+        obj.splitinfo.functions = @(s,t) helm2dquas_c_split(zk,s,t,quas_param,coefs);
+
+    case {'cp', 'cprime'}
+        if ( nargin < 3 )
+            warning('Missing combined layer coefficients. Defaulting to [1,1i].');
+            coefs = [1,1i];
+        end
+        obj.type = 'cprime';
+        obj.params.coefs = coefs;
+        obj.eval = @(s,t) chnk.helm2dquas.kern(zk, s, t, 'cprime',quas_param, coefs);
+        obj.fmm = [];
+        obj.sing = 'hs';
+
+    otherwise
+        error('Unknown Helmholtz kernel type ''%s''.', type);
+
+end
+
+end
+
+function f = helm2dquas_s_split(zk,s,t,quas_param)
+seval = chnk.helm2dquas.kern(zk, s, t, 's',quas_param);
+dist = (s.r(1,:)+1i*s.r(2,:))-(t.r(1,:)'+1i*t.r(2,:)');
+logeval = log(abs(dist));
+f = cell(2,1);
+f{1} = seval + 1/(2*pi)*4*logeval.*imag(seval);
+f{2} = 4*imag(seval);
+end
+
+function f = helm2dquas_d_split(zk,s,t,quas_param)
+deval = chnk.helm2dquas.kern(zk, s, t, 'd',quas_param);
+dist = (s.r(1,:)+1i*s.r(2,:))-(t.r(1,:)'+1i*t.r(2,:)');
+logeval = log(abs(dist));
+cauchyeval = (s.n(1,:)+1i*s.n(2,:))./(dist);
+f = cell(3, 1);
+f{1} = deval + 1/(2*pi)*4*logeval.*imag(deval) + 1/(2*pi)*real(cauchyeval);
+f{2} = 4*imag(deval);
+f{3} = ones(size(t.r,2),size(s.r,2));
+end
+
+function f = helm2dquas_c_split(zk,s,t,quas_param,coefs)
+seval = chnk.helm2dquas.kern(zk, s, t, 's',quas_param);
+deval = chnk.helm2dquas.kern(zk, s, t, 'd',quas_param);
+dist = (s.r(1,:)+1i*s.r(2,:))-(t.r(1,:)'+1i*t.r(2,:)');
+logeval = log(abs(dist));
+cauchyeval = (s.n(1,:)+1i*s.n(2,:))./(dist);
+f = cell(3, 1);
+f{1} = coefs(1) * (deval + 2/pi*logeval.*imag(deval) + 1/(2*pi)*real(cauchyeval)) + ...
+       coefs(2) * (seval + 2/pi*logeval.*imag(seval));
+f{2} = coefs(1) * (4*imag(deval)) + coefs(2) * (4*imag(seval));
+f{3} = coefs(1)*ones(size(t.r,2),size(s.r,2));
+end
+

--- a/chunkie/@kernel/kernel.m
+++ b/chunkie/@kernel/kernel.m
@@ -23,6 +23,8 @@ classdef kernel
 %         ('axissymh', 'axissymhelm')
 %      'axis sym helmholtz difference'              's' 'd' 'sp' 'dp'
 %         ('axissymhdiff', 'axissymhelmdiff') 
+%      'quasiperiodic helmholtz'                    's', 'd', 'sp', 'dp', 'c'
+%         ('helmquas', 'hq')                        'cp'
 %   The types may also be written in longer form, e.g. 'single', 'double',
 %   'sprime', 'combined', 'svelocity', 'spressure', 'straction',
 %   'dvelocity', 'dpressure', 'dtraction'.
@@ -111,7 +113,9 @@ classdef kernel
                       obj = kernel.axissymhelm2d(varargin{:});
                   case {'axis sym helmholtz difference', 'axissymhdiff' ...
                            'axissymhelmdiff'}
-                      obj = kernel.axissymhelm2ddiff(varargin{:});    
+                      obj = kernel.axissymhelm2ddiff(varargin{:});   
+                  case {'quasiperiodic helmholtz', 'helmquas', 'hq'}
+                      obj = kernel.helm2dquas(varargin{:});   
                   otherwise
                       error('Kernel ''%s'' not found.', kern);
               end
@@ -157,6 +161,7 @@ classdef kernel
         obj = elast2d(varargin);
         obj = axissymhelm2d(varargin);
         obj = axissymhelm2ddiff(varargin);
+        obj = helm2dquas(varargin);
         obj = zeros(varargin);
         obj = nans(varargin);
 

--- a/devtools/test/quasiperiodicTest.m
+++ b/devtools/test/quasiperiodicTest.m
@@ -130,54 +130,60 @@ ugrad = chunkerkerneval(chnkr,dgkern,soln,targ);
 
 assert(norm(ugrad-ugradtrue) < 1e-8)
 
-
-% ploting
-Lplot = d/1.5;
-nplot = 80;
-xts = linspace(-Lplot,Lplot,nplot); yts=xts+Lplot/2;
-[X,Y] = meshgrid(xts,yts);
-targ = [X(:).';Y(:).'];
-
-% targ = [2+0*yts;yts];
-ntarg = size(targ,2);
-tic;
-yc = sin_func(X(:),d,A); yc = yc(2,:);
-iup = Y(:).'>yc;
-toc
-targup = targ(:,iup.');
-
-tic;
-uin = NaN*zeros(ntarg,1)+NaN*1i;
-src.n = [0;1];
-uin(iup) = skern.eval(src,struct("r",targup));
-uscat = NaN*zeros(ntarg,1)+NaN*1i;
-opts = []; opts.forcesmooth = false; opts.eps = 1e-6;
+opts = [];
 opts.forcepquad = true; opts.side = 'e';
-uscat(iup) = chunkerkerneval(chnkr,dkern,soln,targup,opts);
-toc
+t = 0;
+targp = sin_func(t,d,A)+1e-2;
+uscatp = chunkerkerneval(chnkr,dkern,soln,targp,opts);
+uinp = skern.eval(src,struct("r",targp));
+assert(abs(uinp-uscatp) < 1e-10)
 
-%
-utot = uin-uscat;
-maxu = max(abs(uin));
-% maxu = .6;
-figure(1);clf
-subplot(1,3,1)
-h = pcolor(X,Y,reshape(imag(uin),nplot,[])); set(h,'edgecolor','none')
-title('$u_{\rm{in}}$','Interpreter','latex'); set(gca,'fontsize',14)
-colorbar; clim([-maxu,maxu])
-hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
-
-subplot(1,3,2)
-h= pcolor(X,Y,reshape(imag(uscat),nplot,[])); set(h,'edgecolor','none')
-title('$u_{\rm{scat}}$','Interpreter','latex'); set(gca,'fontsize',14)
-colorbar; clim([-maxu,maxu])
-hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
-
-subplot(1,3,3)
-h = pcolor(X,Y,reshape(log10(abs(utot)),nplot,[])); set(h,'edgecolor','none')
-title('$\log_{10} $ error','Interpreter','latex'); set(gca,'fontsize',14)
-colorbar; % clim([-maxu,maxu])
-hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+% % ploting
+% Lplot = d/1.5;
+% nplot = 80;
+% xts = linspace(-Lplot,Lplot,nplot); yts=xts+Lplot/2;
+% [X,Y] = meshgrid(xts,yts);
+% targ = [X(:).';Y(:).'];
+% 
+% % targ = [2+0*yts;yts];
+% ntarg = size(targ,2);
+% tic;
+% yc = sin_func(X(:),d,A); yc = yc(2,:);
+% iup = Y(:).'>yc;
+% toc
+% targup = targ(:,iup.');
+% 
+% tic;
+% uin = NaN*zeros(ntarg,1)+NaN*1i;
+% src.n = [0;1];
+% uin(iup) = skern.eval(src,struct("r",targup));
+% uscat = NaN*zeros(ntarg,1)+NaN*1i;
+% opts = []; opts.forcesmooth = false; opts.eps = 1e-6;
+% opts.forcepquad = true; opts.side = 'e';
+% uscat(iup) = chunkerkerneval(chnkr,dkern,soln,targup,opts);
+% toc
+% %
+% utot = uin-uscat;
+% maxu = max(abs(uin));
+% % maxu = .6;
+% figure(1);clf
+% subplot(1,3,1)
+% h = pcolor(X,Y,reshape(imag(uin),nplot,[])); set(h,'edgecolor','none')
+% title('$u_{\rm{in}}$','Interpreter','latex'); set(gca,'fontsize',14)
+% colorbar; clim([-maxu,maxu])
+% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+% 
+% subplot(1,3,2)
+% h= pcolor(X,Y,reshape(imag(uscat),nplot,[])); set(h,'edgecolor','none')
+% title('$u_{\rm{scat}}$','Interpreter','latex'); set(gca,'fontsize',14)
+% colorbar; clim([-maxu,maxu])
+% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+% 
+% subplot(1,3,3)
+% h = pcolor(X,Y,reshape(log10(abs(utot)),nplot,[])); set(h,'edgecolor','none')
+% title('$\log_{10} $ error','Interpreter','latex'); set(gca,'fontsize',14)
+% colorbar; % clim([-maxu,maxu])
+% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
 
 
 end

--- a/devtools/test/quasiperiodicTest.m
+++ b/devtools/test/quasiperiodicTest.m
@@ -138,52 +138,51 @@ uscatp = chunkerkerneval(chnkr,dkern,soln,targp,opts);
 uinp = skern.eval(src,struct("r",targp));
 assert(abs(uinp-uscatp) < 1e-10)
 
-% % ploting
-% Lplot = d/1.5;
-% nplot = 80;
-% xts = linspace(-Lplot,Lplot,nplot); yts=xts+Lplot/2;
-% [X,Y] = meshgrid(xts,yts);
-% targ = [X(:).';Y(:).'];
-% 
-% % targ = [2+0*yts;yts];
-% ntarg = size(targ,2);
-% tic;
-% yc = sin_func(X(:),d,A); yc = yc(2,:);
-% iup = Y(:).'>yc;
-% toc
-% targup = targ(:,iup.');
-% 
-% tic;
-% uin = NaN*zeros(ntarg,1)+NaN*1i;
-% src.n = [0;1];
-% uin(iup) = skern.eval(src,struct("r",targup));
-% uscat = NaN*zeros(ntarg,1)+NaN*1i;
-% opts = []; opts.forcesmooth = false; opts.eps = 1e-6;
-% opts.forcepquad = true; opts.side = 'e';
-% uscat(iup) = chunkerkerneval(chnkr,dkern,soln,targup,opts);
-% toc
-% %
-% utot = uin-uscat;
-% maxu = max(abs(uin));
-% % maxu = .6;
-% figure(1);clf
-% subplot(1,3,1)
-% h = pcolor(X,Y,reshape(imag(uin),nplot,[])); set(h,'edgecolor','none')
-% title('$u_{\rm{in}}$','Interpreter','latex'); set(gca,'fontsize',14)
-% colorbar; clim([-maxu,maxu])
-% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
-% 
-% subplot(1,3,2)
-% h= pcolor(X,Y,reshape(imag(uscat),nplot,[])); set(h,'edgecolor','none')
-% title('$u_{\rm{scat}}$','Interpreter','latex'); set(gca,'fontsize',14)
-% colorbar; clim([-maxu,maxu])
-% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
-% 
-% subplot(1,3,3)
-% h = pcolor(X,Y,reshape(log10(abs(utot)),nplot,[])); set(h,'edgecolor','none')
-% title('$\log_{10} $ error','Interpreter','latex'); set(gca,'fontsize',14)
-% colorbar; % clim([-maxu,maxu])
-% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+% ploting
+Lplot = d/1.5;
+nplot = 50;
+xts = linspace(-Lplot,Lplot,nplot); yts=xts+Lplot/2;
+[X,Y] = meshgrid(xts,yts);
+targ = [X(:).';Y(:).'];
+
+% targ = [2+0*yts;yts];
+ntarg = size(targ,2);
+tic;
+yc = sin_func(X(:),d,A); yc = yc(2,:);
+iup = Y(:).'>yc;
+toc
+targup = targ(:,iup.');
+
+tic;
+uin = NaN*zeros(ntarg,1)+NaN*1i;
+src.n = [0;1];
+uin(iup) = skern.eval(src,struct("r",targup));
+uscat = NaN*zeros(ntarg,1)+NaN*1i;
+opts = []; opts.forcesmooth = false; opts.eps = 1e-6;
+opts.forcepquad = true; opts.side = 'e';
+uscat(iup) = chunkerkerneval(chnkr,dkern,soln,targup,opts);
+toc
+%
+utot = uin-uscat;
+maxu = max(abs(uin));
+figure(1);clf
+subplot(1,3,1)
+h = pcolor(X,Y,reshape(imag(uin),nplot,[])); set(h,'edgecolor','none')
+title('$u_{\rm{true}}$','Interpreter','latex'); set(gca,'fontsize',14)
+colorbar; clim([-maxu,maxu])
+hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+
+subplot(1,3,2)
+h= pcolor(X,Y,reshape(imag(uscat),nplot,[])); set(h,'edgecolor','none')
+title('$u$','Interpreter','latex'); set(gca,'fontsize',14)
+colorbar; clim([-maxu,maxu])
+hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+
+subplot(1,3,3)
+h = pcolor(X,Y,reshape(log10(abs(utot)),nplot,[])); set(h,'edgecolor','none')
+title('$\log_{10} $ error','Interpreter','latex'); set(gca,'fontsize',14)
+colorbar; 
+hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
 
 
 end

--- a/devtools/test/quasiperiodicTest.m
+++ b/devtools/test/quasiperiodicTest.m
@@ -1,0 +1,190 @@
+quasiperiodicTest0();
+quasiperiodicTest1();
+
+function quasiperiodicTest0()
+% test the representation
+
+% problem parameters
+d= 1;
+zk = 1;
+kappa = pi-0.1-1i;
+coefs = [1;0.5];
+coefa = [1,0.3;-1i,0.2];
+
+src = []; src.r = [0;-1]; src.n = [1;-2];
+targ = []; targ.r = [1.1;0.3]; targ.n = [-1;0.3];
+
+% kernels
+skern = kernel('hq','s',zk,kappa,d);
+dkern = kernel('hq','d',zk,kappa,d);
+ckern = kernel('hq','c',zk,kappa,d,coefs);
+
+spkern = kernel('hq','sp',zk,kappa,d);
+dpkern = kernel('hq','dp',zk,kappa,d);
+cpkern = kernel('hq','cp',zk,kappa,d,coefs);
+
+quas_param = skern.params.quas_param;
+
+allkern = kernel(@(s,t) chnk.helm2dquas.kern(zk,s,t,'all',quas_param,coefa));
+trkern = kernel(@(s,t) chnk.helm2dquas.kern(zk,s,t,'trans_rep',quas_param,coefs));
+trpkern = kernel(@(s,t) chnk.helm2dquas.kern(zk,s,t,'trans_rep_prime',quas_param,coefs));
+
+sgkern = kernel(@(s,t) chnk.helm2dquas.kern(zk,s,t,'sgrad',quas_param));
+dgkern = kernel(@(s,t) chnk.helm2dquas.kern(zk,s,t,'dgrad',quas_param));
+cgkern = kernel(@(s,t) chnk.helm2dquas.kern(zk,s,t,'cgrad',quas_param,coefs));
+trgkern = kernel(@(s,t) chnk.helm2dquas.kern(zk,s,t,'trans_rep_grad',quas_param,coefs));
+
+c2trkern = kernel(@(s,t) chnk.helm2dquas.kern(zk,s,t,'c2trans',quas_param,coefs));
+
+% evaluate kernels
+sval = skern.eval(src,targ);
+dval = dkern.eval(src,targ);
+cval = ckern.eval(src,targ);
+trval = trkern.eval(src,targ);
+
+spval = spkern.eval(src,targ);
+dpval = dpkern.eval(src,targ);
+cpval = cpkern.eval(src,targ);
+trpval = trpkern.eval(src,targ);
+
+sgval = sgkern.eval(src,targ);
+dgval = dgkern.eval(src,targ);
+cgval = cgkern.eval(src,targ);
+trgval = trgkern.eval(src,targ);
+
+allval = allkern.eval(src,targ);
+
+c2trval = c2trkern.eval(src,targ);
+
+
+% test quasiperiodicitiy
+targ_s = targ; targ_s.r = targ.r + [d;0];
+svalshift = skern.eval(src,targ_s);
+assert(abs(svalshift - exp(1i*kappa*d)*sval) <  1e-12)
+
+% test combined
+assert(abs((coefs(1)*dval + coefs(2)*sval)-cval) <  1e-12)
+assert(abs((coefs(1)*dpval + coefs(2)*spval)-cpval) <  1e-12)
+
+% test all
+assert(norm([coefa(1,1)*dval, coefa(1,2)*sval; coefa(2,1)*dpval, ...
+    coefa(2,2)*spval] - allval) <  1e-12)
+
+% test transmission representiatoon
+assert(norm([coefs(1)*dval , coefs(2)*sval]-trval) <  1e-12)
+assert(norm([coefs(1)*dpval , coefs(2)*spval]-trpval) <  1e-12)
+
+% test gradients
+assert(norm((coefs(1)*dgval + coefs(2)*sgval)-cgval) <  1e-12)
+assert(norm([coefs(1)*dgval , coefs(2)*sgval]-trgval) <  1e-12)
+
+% test c2trans
+assert(norm([coefs(1)*dval + coefs(2)*sval; coefs(1)*dpval + coefs(2)*spval]-c2trval) <  1e-12)
+end
+
+
+function quasiperiodicTest1()
+% test an integral equation
+
+
+% problem parameters
+d= 8;
+zk = 1;
+kappa = .05+0.1i;
+
+% setup geometry
+nch = 2^3;
+A = .2;
+cparams = []; cparams.ta = -d/2; cparams.tb = d/2;
+chnkr = chunkerfuncuni(@(t) sin_func(t,d,A),nch,cparams);
+chnkr = reverse(chnkr);
+
+% setup system
+skern = kernel('hq','s',zk,kappa,d);
+dkern = kernel('hq','d',zk,kappa,d);
+
+sysmat = chunkermat(chnkr,dkern);
+sysmat = sysmat + .5*eye(size(sysmat,2));
+
+% solve
+src = struct("r",[3*d/4;-1.5]);
+
+rhs = skern.eval(src,chnkr);
+
+soln = sysmat\rhs;
+
+% check analytic solution
+targ = [10*d/3;2];
+utrue = skern.eval(src,struct("r",targ));
+u = chunkerkerneval(chnkr,dkern,soln,targ);
+
+assert(abs(u-utrue) < 1e-10)
+
+% check gradient
+quas_param = skern.params.quas_param;
+sgkern = @(s,t) chnk.helm2dquas.kern(zk,s,t,'sgrad',quas_param);
+dgkern = @(s,t) chnk.helm2dquas.kern(zk,s,t,'dgrad',quas_param);
+
+ugradtrue = sgkern(src,struct("r",targ));
+ugrad = chunkerkerneval(chnkr,dgkern,soln,targ);
+
+assert(norm(ugrad-ugradtrue) < 1e-8)
+
+
+% ploting
+% Lplot = d/2;
+% nplot = 80;
+% xts = linspace(-Lplot,Lplot,nplot); yts=xts+Lplot/2;
+% [X,Y] = meshgrid(xts,yts);
+% targ = [X(:).';Y(:).'];
+% 
+% % targ = [2+0*yts;yts];
+% ntarg = size(targ,2);
+% tic;
+% yc = sin_func(X(:),d,A); yc = yc(2,:);
+% iup = Y(:).'>yc;
+% toc
+% targup = targ(:,iup.');
+% 
+% tic;
+% uin = NaN*zeros(ntarg,1)+NaN*1i;
+% src.n = [0;1];
+% uin(iup) = skern.eval(src,struct("r",targup));
+% uscat = NaN*zeros(ntarg,1)+NaN*1i;
+% opts = []; %opts.forcesmooth = false; opts.eps = 1e-6;
+% % opts.forcepquad = true; opts.side = 'e';
+% uscat(iup) = chunkerkerneval(chnkr,dkern,soln,targup,opts);
+% toc
+% 
+% %
+% utot = uin-uscat;
+% maxu = max(abs(uin));
+% % maxu = .6;
+% figure(1);clf
+% subplot(1,3,1)
+% h = pcolor(X,Y,reshape(imag(uin),nplot,[])); set(h,'edgecolor','none')
+% title('$u_{\rm{in}}$','Interpreter','latex'); set(gca,'fontsize',14)
+% colorbar; clim([-maxu,maxu])
+% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+% 
+% subplot(1,3,2)
+% h= pcolor(X,Y,reshape(imag(uscat),nplot,[])); set(h,'edgecolor','none')
+% title('$u_{\rm{scat}}$','Interpreter','latex'); set(gca,'fontsize',14)
+% colorbar; clim([-maxu,maxu])
+% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+% 
+% subplot(1,3,3)
+% h = pcolor(X,Y,reshape(log10(abs(utot)),nplot,[])); set(h,'edgecolor','none')
+% title('$\log_{10} $ error','Interpreter','latex'); set(gca,'fontsize',14)
+% colorbar; % clim([-maxu,maxu])
+% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+
+
+end
+
+function [r,d,d2] = sin_func(t,d,A)
+omega = 2*pi/d;
+r = [t, A*sin(omega*t)].';
+d = [ones(length(t),1), omega*A*cos(omega*t)].';
+d2 = [zeros(length(t),1), -omega^2*A*sin(omega*t)].';
+end

--- a/devtools/test/quasiperiodicTest.m
+++ b/devtools/test/quasiperiodicTest.m
@@ -132,52 +132,52 @@ assert(norm(ugrad-ugradtrue) < 1e-8)
 
 
 % ploting
-% Lplot = d/2;
-% nplot = 80;
-% xts = linspace(-Lplot,Lplot,nplot); yts=xts+Lplot/2;
-% [X,Y] = meshgrid(xts,yts);
-% targ = [X(:).';Y(:).'];
-% 
-% % targ = [2+0*yts;yts];
-% ntarg = size(targ,2);
-% tic;
-% yc = sin_func(X(:),d,A); yc = yc(2,:);
-% iup = Y(:).'>yc;
-% toc
-% targup = targ(:,iup.');
-% 
-% tic;
-% uin = NaN*zeros(ntarg,1)+NaN*1i;
-% src.n = [0;1];
-% uin(iup) = skern.eval(src,struct("r",targup));
-% uscat = NaN*zeros(ntarg,1)+NaN*1i;
-% opts = []; %opts.forcesmooth = false; opts.eps = 1e-6;
-% % opts.forcepquad = true; opts.side = 'e';
-% uscat(iup) = chunkerkerneval(chnkr,dkern,soln,targup,opts);
-% toc
-% 
-% %
-% utot = uin-uscat;
-% maxu = max(abs(uin));
-% % maxu = .6;
-% figure(1);clf
-% subplot(1,3,1)
-% h = pcolor(X,Y,reshape(imag(uin),nplot,[])); set(h,'edgecolor','none')
-% title('$u_{\rm{in}}$','Interpreter','latex'); set(gca,'fontsize',14)
-% colorbar; clim([-maxu,maxu])
-% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
-% 
-% subplot(1,3,2)
-% h= pcolor(X,Y,reshape(imag(uscat),nplot,[])); set(h,'edgecolor','none')
-% title('$u_{\rm{scat}}$','Interpreter','latex'); set(gca,'fontsize',14)
-% colorbar; clim([-maxu,maxu])
-% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
-% 
-% subplot(1,3,3)
-% h = pcolor(X,Y,reshape(log10(abs(utot)),nplot,[])); set(h,'edgecolor','none')
-% title('$\log_{10} $ error','Interpreter','latex'); set(gca,'fontsize',14)
-% colorbar; % clim([-maxu,maxu])
-% hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+Lplot = d/1.5;
+nplot = 80;
+xts = linspace(-Lplot,Lplot,nplot); yts=xts+Lplot/2;
+[X,Y] = meshgrid(xts,yts);
+targ = [X(:).';Y(:).'];
+
+% targ = [2+0*yts;yts];
+ntarg = size(targ,2);
+tic;
+yc = sin_func(X(:),d,A); yc = yc(2,:);
+iup = Y(:).'>yc;
+toc
+targup = targ(:,iup.');
+
+tic;
+uin = NaN*zeros(ntarg,1)+NaN*1i;
+src.n = [0;1];
+uin(iup) = skern.eval(src,struct("r",targup));
+uscat = NaN*zeros(ntarg,1)+NaN*1i;
+opts = []; opts.forcesmooth = false; opts.eps = 1e-6;
+opts.forcepquad = true; opts.side = 'e';
+uscat(iup) = chunkerkerneval(chnkr,dkern,soln,targup,opts);
+toc
+
+%
+utot = uin-uscat;
+maxu = max(abs(uin));
+% maxu = .6;
+figure(1);clf
+subplot(1,3,1)
+h = pcolor(X,Y,reshape(imag(uin),nplot,[])); set(h,'edgecolor','none')
+title('$u_{\rm{in}}$','Interpreter','latex'); set(gca,'fontsize',14)
+colorbar; clim([-maxu,maxu])
+hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+
+subplot(1,3,2)
+h= pcolor(X,Y,reshape(imag(uscat),nplot,[])); set(h,'edgecolor','none')
+title('$u_{\rm{scat}}$','Interpreter','latex'); set(gca,'fontsize',14)
+colorbar; clim([-maxu,maxu])
+hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
+
+subplot(1,3,3)
+h = pcolor(X,Y,reshape(log10(abs(utot)),nplot,[])); set(h,'edgecolor','none')
+title('$\log_{10} $ error','Interpreter','latex'); set(gca,'fontsize',14)
+colorbar; % clim([-maxu,maxu])
+hold on, plot(chnkr,'.'), plot(src.r(1,:),src.r(2,:),'o','LineWidth',2), hold off
 
 
 end


### PR DESCRIPTION
This pull request adds quasiperiodic Helmholtz kernels, computed using lattice sums.

Kernels satisfy quasi periodicity in the x-direction, i.e. G(x + de_1, y) = exp(i alpha d) G(x,y)

For small x_2 - y_2, G is computed by building a local expansion (see Sn) encompassing all far sources. For large x_2-y_2, G is computed as a sum over the dual lattice.

Due to the weird singularity locations, the integration routines only behave as expected when, x,y are in [-d/2,d/2], but I don't see a clean built-in way. It is easy to fix post processing using quasiperiodicity.

I included a little analytic solution test to verify accuracy and kernel splitting formula.
I also added tests that confirm quasiperiodicity and the expected relationship between kernels, i.e. k_C = ak_D + bk_S.