### PR TITLE
Add higher-order diffmats and clean up diffmat

### DIFF
--- a/chunkie/@chunker/diffmat.m
+++ b/chunkie/@chunker/diffmat.m
@@ -1,19 +1,68 @@
-function dmat = diffmat(chnkr, rect_flag)
-%DIFFMAT returns the matrix of arc length differentiation along the 
-% chunker object 
+function D = diffmat(chnkr, p, type)
+%DIFFMAT spectral differentiation matrix with respect to arc length along a
+% chunker object
+%
+% Syntax: chnkr = DIFFMAT(chnkr, p, type)
+%
+% Input:
+%   chnkr - the chunker object
+%
+% Optional inputs:
+%   p    - differentiation order (1)
+%   type - type of spectral differentiation ('square')
+%          - 'square' maps from an n-point grid to an n-point grid on each
+%            panel.
+%          - 'rectangular' maps from an n-point grid to an (n-p)-point grid
+%            on each panel.
+%
+% Output:
+%   D - chnkr.npt x chnkr.npt sparse block-diagonal differentiation matrix
+%
+% Examples:
+%   D = diffmat(chnkr);
+%   D = diffmat(chnkr, 2);
+%   D = diffmat(chnkr, 'rect');
+%
+% See also INTMAT.
 
-	if (nargin < 2)
-		rect_flag = false;
-	end
-	tdiff = reshape(lege.dermat(chnkr.k), [chnkr.k, chnkr.k, 1]);
-	ds = reshape(vecnorm(chnkr.d), [chnkr.k, 1, chnkr.nch]);
-	dmat = (1./ds) .* tdiff;
-	if rect_flag
-		[~, ~, u, ~] = lege.exps(chnkr.k);
-		[~, ~, ~, v] = lege.exps(chnkr.k - 1);
-		tmp = v * u(1:end-1, :);
-		dmat = pagemtimes(tmp, dmat);
-	end
-	dmat = num2cell(dmat, [1 2]);	
-	dmat = blkdiag(dmat{:});
+if ( nargin < 2 )
+    p = 1;
+    type = 'square';
+end
+
+if ( nargin < 3 )
+    if ( isstring(p) || ischar(p) )
+        type = p;
+        p = 1;
+    else
+        type = 'square';
+    end
+end
+
+if ( ~(isnumeric(p) && isscalar(p) && p>=0 && floor(p) == p) )
+    error('CHUNKER:DIFFMAT:order', ...
+        'Differentiation order must be a nonnegative integer.');
+end
+
+n = chnkr.k;
+Dleg = lege.dermat(n);
+ds = reshape(vecnorm(chnkr.d), [n 1 chnkr.nch]);
+D = Dleg ./ ds;
+
+% Take p-th derivative
+for k = 1:chnkr.nch
+    D(:,:,k) = D(:,:,k)^p;
+end
+
+if ( strcmpi(type, 'rect') )
+    [~, ~, CfV, ~] = lege.exps(n);
+    [~, ~, ~, VfC] = lege.exps(n-p);
+	P = VfC * CfV(1:n-p,:);
+	D = pagemtimes(P, D);
+end
+
+% Output a sparse block-diagonal matrix
+D = num2cell(D, [1 2]);
+D = matlab.internal.math.blkdiag(D{:});
+
 end

--- a/devtools/test/chunker_diffintmatTest.m
+++ b/devtools/test/chunker_diffintmatTest.m
@@ -3,30 +3,25 @@ chunker_diffintmatTest0();
 function chunker_diffintmatTest0()
 chnkr = chunkerfunc(@(t) [cos(t)'; 5*sin(t)']);
 
-diffmat = chnkr.diffmat();
-intmat = chnkr.intmat();
+D = diffmat(chnkr);
+C = intmat(chnkr);
 
-dx = diffmat * chnkr.r(1, 1:end)';
-dy = diffmat * chnkr.r(2, 1:end)';
+dx = D * chnkr.r(1,:).';
+dy = D * chnkr.r(2,:).';
 
 % Check that (dx, dy) are unit tangent vectors
 assert(vecnorm(dx.^2 + dy.^2 - 1) < 1e-10);
 
-x = intmat * dx;
-y = intmat * dy;
-
-diffmat = chnkr.diffmat(false); %test rectangular derivative operator
-dx = diffmat * chnkr.r(1, 1:end)';
-dy = diffmat * chnkr.r(2, 1:end)';
-
-assert(vecnorm(dx.^2 + dy.^2 - 1) < 1e-10);
+x = C * dx;
+y = C * dy;
 
 % Check that integral and derivative are inverse up to a scalar
-assert(vecnorm(x - x(1) - chnkr.r(1, 1:end)' + chnkr.r(1, 1)) < 1e-10);
-assert(vecnorm(y - y(1) - chnkr.r(2, 1:end)' + chnkr.r(2, 1)) < 1e-10);
+assert(vecnorm(x - x(1) - chnkr.r(1,:).' + chnkr.r(1,1)) < 1e-10);
+assert(vecnorm(y - y(1) - chnkr.r(2,:).' + chnkr.r(2,1)) < 1e-10);
 
 chnkr = chunkerfunc(@(t) [cos(t)'; sin(t)']);
-diffmat = chnkr.diffmat();
-test_quant = diffmat * chnkr.r(1, 1:end)' + chnkr.r(2, 1:end)';
+D = diffmat(chnkr);
+test_quant = D * chnkr.r(1,:).' + chnkr.r(2,:).';
 assert(vecnorm(test_quant) < 1e-10);
+
 end


### PR DESCRIPTION
This PR adds support for higher-order square and rectangular `diffmat`s. I've cleaned up the code and added more documentation.

```
D = diffmat(chnkr);
D = diffmat(chnkr, 2);
D = diffmat(chnkr, 'rect');
D = diffmat(chnkr, 2, 'rect');
```