### PR TITLE
Fix quas periodic

### DIFF
--- a/chunkie/+chnk/+helm2dquas/green.m
+++ b/chunkie/+chnk/+helm2dquas/green.m
@@ -120,9 +120,17 @@ if ~isempty(rxclose)
     sn = sn.';
     N = length(sn)-1;
     ns = (0:N);
+    ns_use = (0:N+2);
     Js = zeros(length(rclose),N+3);
-    for i = 1:length(rclose)
-    Js(i,:) = besselj((0:N+2),zk*rclose(i));
+
+    if length(rclose) < N+3
+        for i = 1:length(rclose)
+        Js(i,:) = besselj(ns_use,zk*rclose(i));
+        end
+    else
+        for i = 1:length(ns_use)
+        Js(:,i) = besselj(ns_use(i),zk*rclose);
+        end
     end
     eip = (rxclose+1i*ryclose)./rclose;
     cs = (eip.^ns+eip.^(-ns))/2;

--- a/chunkie/+chnk/+helm2dquas/green.m
+++ b/chunkie/+chnk/+helm2dquas/green.m
@@ -23,8 +23,8 @@ yt = repmat(targ(2,:).',1,nsrc);
 rx = xt-xs;
 ry = yt-ys;
 
-nx = fix(rx/l/d);
-rx = rx - nx*l*d;
+nx = fix(rx/d);
+rx = rx - nx*d;
 
 
 rx2 = rx.*rx;
@@ -175,7 +175,7 @@ if ~isempty(rxclose)
     end
 end
 
-quasi_phase = exp(1i*kappa*nx(:)*l*d);
+quasi_phase = exp(1i*kappa*nx(:)*d);
 
 val = reshape(quasi_phase.*val,ntarg,nsrc);
 if nargout>1

--- a/chunkie/+chnk/+helm2dquas/green.m
+++ b/chunkie/+chnk/+helm2dquas/green.m
@@ -4,7 +4,7 @@ function [val,grad,hess] = green(src,targ,zk,kappa,d,sn,l)
 %
 % Input:
 %   zk - wavenumber
-%   kappa - quasiperiodic parameter
+%   kappa - quasiperiodic parameters
 %   d - period
 %   sn - precomputed lattice sum integrals 
 %       (see chnk.helm2dquas.latticecoefs)
@@ -52,73 +52,80 @@ rxclose = rx(iclose);
 ryclose = ry(iclose);
 rclose = r(iclose);
 
+nkappa = length(kappa);
 
-val = zeros(npt,1);
+val = zeros(nkappa,npt,1);
 if nargout > 1
-grad = zeros(npt,2);
+grad = zeros(nkappa,npt,2);
 end
 if nargout > 2
-hess = zeros(npt,3);
+hess = zeros(nkappa,npt,3);
 end
 
 
 tol = 1e-10;
 Lbd = sqrt((log(tol))^2/real(ythresh)^2 + real(zk)^2);
 
+rxfar = rxfar.';
+ryfar = ryfar.';
 if ~isempty(ryfar)
 M = ceil(Lbd*d/(2*pi));
-ms = (-M:M);
-xi_m = kappa + 2*pi/d*ms;
+ms = reshape((-M:M),1,1,[]);
+xi_m = kappa(:) + 2*pi/d*ms;
 
 % beta = sqrt((xi_m.^2-zk^2));
 beta = sqrt(1i*(xi_m-zk)).*sqrt(-1i*(xi_m+zk));
 
-fhat = exp(-beta.*sqrt(ryfar.^2))./beta.*exp(1i*xi_m.*rxfar)/2;
-val(ifar,:) = sum(fhat,2)/(d);
+% fhat = exp(-beta.*sqrt(ryfar.^2))./beta.*exp(1i*xi_m.*rxfar)/2;
+fhat = exp(-beta.*sqrt(ryfar.^2) + 1i*xi_m.*rxfar)./(2*beta);
+val(:,ifar,:) = sum(fhat,3)/(d);
 if nargout > 1
-gx = sum(1i*xi_m.*fhat,2)/d;
-gy = sum(-beta.*(sqrt(ryfar.^2)./ryfar).*fhat,2)/d;
-grad(ifar,:) =[gx,gy];
+grad(:,ifar,1) = sum(1i*xi_m.*fhat,3)/d;
+grad(:,ifar,2) = sum(-beta.*(sqrt(ryfar.^2)./ryfar).*fhat,3)/d;
+% grad(:,ifar,:) =[gx,gy];
 end
 
 if nargout >2
-hxx = sum(-xi_m.^2.*fhat,2)/d;
-hxy = sum(-1i*xi_m.*beta.*(sqrt(ryfar.^2)./ryfar).*fhat,2)/d;
-hyy = sum((beta.*(sqrt(ryfar.^2)./ryfar)).^2.*fhat,2)/d;
-hess(ifar,:) = [hxx,hxy,hyy];
+hess(:,ifar,1) = sum(-xi_m.^2.*fhat,3)/d;
+hess(:,ifar,2) = sum(-1i*xi_m.*beta.*(sqrt(ryfar.^2)./ryfar).*fhat,3)/d;
+hess(:,ifar,3) = sum((beta.*(sqrt(ryfar.^2)./ryfar)).^2.*fhat,3)/d;
+% hess(:,ifar,:) = [hxx,hxy,hyy];
 end
 
 
 end
 
-alpha = (exp(1i*kappa*d));
+alpha = (exp(1i*kappa(:)*d));
 
 val_near=0;
-grad_near = [0,0];
-hess_near = [0,0,0];
+grad_near = zeros(1,1,2);
+hess_near = zeros(1,1,3);
 if ~isempty(rxclose)
     for i = -l:l
         rxi = rxclose - i*d;
         if nargout>2
         [vali,gradi,hessi] = chnk.helm2d.green(zk,[0;0],[rxi.';ryclose.']);
-        gradi = reshape(gradi,[],2);
-        hessi = reshape(hessi,[],3);
-        val_near = val_near + vali*alpha^i;
-        grad_near = grad_near + gradi*alpha^i;
-        hess_near = hess_near + hessi*alpha^i;
+        vali = reshape(vali,1,[],1);
+        gradi = reshape(gradi,1,[],2);
+        hessi = reshape(hessi,1,[],3);
+        val_near = val_near + vali.*alpha.^i;
+        grad_near = grad_near + gradi.*alpha.^i;
+        hess_near = hess_near + hessi.*alpha.^i;
         elseif nargout > 1
         [vali,gradi] = chnk.helm2d.green(zk,[0;0],[rxi.';ryclose.']);
-        gradi = reshape(gradi,[],2);
-        val_near = val_near + vali*alpha^i;
-        grad_near = grad_near + gradi*alpha^i;
+        vali = reshape(vali,1,[],1);
+        gradi = reshape(gradi,1,[],2);
+        val_near = val_near + vali.*alpha.^i;
+        grad_near = grad_near + gradi.*alpha.^i;
         else
         vali = chnk.helm2d.green(zk,[0;0],[rxi.';ryclose.']);
-        val_near = val_near + vali*alpha^i;
+        vali = reshape(vali,1,[],1);
+        val_near = val_near + vali.*alpha.^i;
         end
     end
     
-    sn = sn.';
-    N = length(sn)-1;
+    % sn = sn.';
+    N = size(sn,2)-1;
     ns = (0:N);
     ns_use = (0:N+2);
     Js = zeros(length(rclose),N+3);
@@ -133,64 +140,67 @@ if ~isempty(rxclose)
         end
     end
     eip = (rxclose+1i*ryclose)./rclose;
-    cs = (eip.^ns+eip.^(-ns))/2;
+    eipn = reshape(eip.^ns,1,[], N+1);
+    cs = (eipn+1./eipn)/2;
     
+    Js = reshape(Js,1,[],N+3);
+    sn = reshape(sn,nkappa, 1, N+1);
     
-    val_far = 0.25*1i*Js(:,1)*sn(1) + 0.5*1i*sum(sn(2:end).*Js(:,2:end-2).*cs(:,2:end),2);
-    val(iclose) = val_near+val_far;
+    val_far = 0.25*1i*Js(:,:,1).*sn(:,:,1) + 0.5*1i*sum(sn(:,:,2:end).*Js(:,:,2:end-2).*cs(:,:,2:end),3);
+    val(:,iclose) = val_near+val_far;
     
     
     
     
     if nargout >1
-        DJs = [-Js(:,2),.5*(Js(:,1:end-3)-Js(:,3:end-1))]*zk;
-        ss = (eip.^ns-eip.^(-ns))/2i;
+        DJs = cat(3,-Js(:,:,2),.5*(Js(:,:,1:end-3)-Js(:,:,3:end-1)))*zk;
+        ss = (eipn-1./eipn)/2i;
             
-        grad_far_p = 0.25*1i*DJs(:,1)*sn(1) + 0.5*1i*sum(sn(2:end).*DJs(:,2:end).*cs(:,2:end),2);
-        grad_far_t = (0.5*1i*sum(-(1:N).*sn(2:end).*Js(:,2:end-2).*ss(:,2:end),2))./rclose;
+        grad_far_p = 0.25*1i*DJs(:,:,1).*sn(:,:,1) + 0.5*1i*sum(sn(:,:,2:end).*DJs(:,:,2:end).*cs(:,:,2:end),3);
+        grad_far_t = (0.5*1i*sum(-reshape((1:N),1,1,[]).*sn(:,:,2:end).*Js(:,:,2:end-2).*ss(:,:,2:end),3))./rclose.';
         
-        grad_far = [cs(:,2).*grad_far_p - ss(:,2).*grad_far_t, ss(:,2).*grad_far_p + cs(:,2).*grad_far_t];
-    
-        grad(iclose,:) = grad_near + grad_far; 
+        grad_far = cat(3,cs(:,:,2).*grad_far_p - ss(:,:,2).*grad_far_t, ss(:,:,2).*grad_far_p + cs(:,:,2).*grad_far_t);
+        grad(:,iclose,:) = grad_near + grad_far; 
     end
     if nargout > 2
-        DDJs = [.5*(Js(:,3)-Js(:,1)),.25*(Js(:,4)-3*Js(:,2)),.25*(Js(:,1:end-4)-2*Js(:,3:end-2)+Js(:,5:end))]*zk^2;
+        DDJs = cat(3,.5*(Js(:,:,3)-Js(:,:,1)),.25*(Js(:,:,4)-3*Js(:,:,2)),.25*(Js(:,:,1:end-4)-2*Js(:,:,3:end-2)+Js(:,:,5:end)))*zk^2;
+        rclose = rclose.';
+        rxclose = rxclose.';
+        ryclose = ryclose.';
+        ns = reshape(ns,1,1,[]);
 
-
-        tmp_n = rclose.^(-4).*(-ns.*ryclose.*Js(:,1:end-2).*(ns.*ryclose.*cs+2*rxclose.*ss)+ ...
+        tmp_n = rclose.^(-4).*(-ns.*ryclose.*Js(:,:,1:end-2).*(ns.*ryclose.*cs+2*rxclose.*ss)+ ...
             rclose.*ryclose.*(ryclose.*cs + 2*ns.*rxclose.*ss).*DJs+ ...
             rclose.^2.*rxclose.^2.*cs.*DDJs);
-        hess_far_xx = 0.25*1i*tmp_n(:,1)*sn(1)+.5*1i*sum(sn(2:end).*tmp_n(:,2:end),2);
+        hess_far_xx = 0.25*1i*tmp_n(:,:,1).*sn(:,:,1)+.5*1i*sum(sn(:,:,2:end).*tmp_n(:,:,2:end),3);
 
-        tmp_n = ns.*Js(:,1:end-2).*(ns.*rxclose.*ryclose.*cs+(rxclose.^2-ryclose.^2).*ss).*rclose.^(-4) ...
+        tmp_n = ns.*Js(:,:,1:end-2).*(ns.*rxclose.*ryclose.*cs+(rxclose.^2-ryclose.^2).*ss).*rclose.^(-4) ...
             +rclose.^(-3).*(-(rxclose.*ryclose.*cs+ns.*(rxclose.^2-ryclose.^2).*ss).*DJs+...
             rclose.*rxclose.*ryclose.*cs.*DDJs);
 
 
-        hess_far_xy = 0.25*1i*tmp_n(:,1)*sn(1)+.5*1i*sum(sn(2:end).*tmp_n(:,2:end),2);
+        hess_far_xy = 0.25*1i*tmp_n(:,:,1).*sn(:,:,1)+.5*1i*sum(sn(:,:,2:end).*tmp_n(:,:,2:end),3);
 
-        tmp_n = rclose.^(-4).*(-ns.*rxclose.*Js(:,1:end-2).*(ns.*rxclose.*cs-2*ryclose.*ss)+ ...
+        tmp_n = rclose.^(-4).*(-ns.*rxclose.*Js(:,:,1:end-2).*(ns.*rxclose.*cs-2*ryclose.*ss)+ ...
             rclose.*rxclose.*(rxclose.*cs - 2*ns.*ryclose.*ss).*DJs+ ...
             rclose.^2.*ryclose.^2.*cs.*DDJs);
-        hess_far_yy = 0.25*1i*tmp_n(:,1)*sn(1)+.5*1i*sum(sn(2:end).*tmp_n(:,2:end),2);
+        hess_far_yy = 0.25*1i*tmp_n(:,:,1).*sn(:,:,1)+.5*1i*sum(sn(:,:,2:end).*tmp_n(:,:,2:end),3);
+
+        hess_far = cat(3,hess_far_xx, hess_far_xy, hess_far_yy);
 
 
-
-        hess_far = [hess_far_xx, hess_far_xy, hess_far_yy];
-
-
-        hess(iclose,:) = hess_near + hess_far;
+        hess(:,iclose,:) = hess_near + hess_far;
     end
 end
 
-quasi_phase = exp(1i*kappa*nx(:)*d);
+quasi_phase = exp(1i*kappa(:)*nx(:).'*d);
 
-val = reshape(quasi_phase.*val,ntarg,nsrc);
+val = reshape(quasi_phase.*val,nkappa*ntarg,nsrc);
 if nargout>1
-grad = reshape(quasi_phase.*grad,ntarg,nsrc,2);
+grad = reshape(quasi_phase.*grad,nkappa*ntarg,nsrc,2);
 end
 if nargout>2
-hess = reshape(quasi_phase.*hess,ntarg,nsrc,3);
+hess = reshape(quasi_phase.*hess,nkappa*ntarg,nsrc,3);
 end
 % end
 

--- a/chunkie/+chnk/+helm2dquas/latticecoefs.m
+++ b/chunkie/+chnk/+helm2dquas/latticecoefs.m
@@ -12,23 +12,30 @@ function S = latticecoefs(n,zk,d,kappa,alpha,a,M,l)
 %
 % quasi periodic parameters:
 %   d - period
-%   kappa - quasiperiodic parameter
+%   kappa - quasiperiodic parameters
 %   alpha - exp(1i*d*kappa), chosen so that u(x+d) = alpha * u(x)
 
 if nargin < 8, l = 2; end
 taus = linspace(0,a,M)*(1-1i);
+
+nkappa = length(kappa);
+S = zeros(nkappa,length(n));
 
 sq_taus = sqrt(1-taus.^2);
 
 Gp = exp(n*log(taus - 1i*sq_taus) +l*1i*zk*d*sq_taus);
 Gm = exp(n*log(-taus - 1i*sq_taus) +l*1i*zk*d*sq_taus);
 
-Fp = 1./(sq_taus.*(1-exp(1i*zk*d.*(sq_taus-kappa*d./zk/d))));
-Fm = 1./(sq_taus.*(1-exp(1i*zk*d.*(sq_taus+kappa*d./zk/d))));
+
+for i = 1:nkappa
+
+Fp = 1./(sq_taus.*(1-exp(1i*zk*d.*(sq_taus-kappa(i)*d./zk/d))));
+Fm = 1./(sq_taus.*(1-exp(1i*zk*d.*(sq_taus+kappa(i)*d./zk/d))));
 
 S_p = sum((Gp+Gm).*Fp,2)-(Gp(:,1)+Gm(:,1)).*Fp(:,1)/2;
 S_m = sum((Gp+Gm).*Fm,2)-(Gp(:,1)+Gm(:,1)).*Fm(:,1)/2;
 
-S = -1i*exp(1i*pi/4)*sqrt(2)/pi*((-1).^n.*alpha^(-l).*S_p+alpha^(l)*S_m)*a/(M-1);
+S(i,:) = -1i*exp(1i*pi/4)*sqrt(2)/pi*((-1).^n.*alpha(i)^(-l).*S_p+alpha(i)^(l)*S_m)*a/(M-1);
+end
 
 end

--- a/chunkie/@kernel/helm2dquas.m
+++ b/chunkie/@kernel/helm2dquas.m
@@ -24,6 +24,11 @@ function obj = helm2dquas(type, zk, kappa, d, coefs, quad_opts)
 %   constructs the derivative of the combined-layer Helmholtz kernel with 
 %   parameter ETA, i.e., COEFS(1)*KERNEL.HELM2DQUAS('dp', ZK, KAPPA, D) + 
 %      COEFS(2)*KERNEL.HELM2DQUAS('sp', ZK, KAPPA, D).
+%
+%   if kappa is an array of values of length nkappa then the kernel 
+%   becomes an (nkappa x 1) vector-valued kernel containing the scalar values
+%   for each kappa. this is much more efficient than separate kernel 
+%   evaluations for each kappa.
 %   
 %   all versions accept quad_opts to change the parameters in the lattice
 %   sum computations. (see chnk.helm2dquas.latticecoefs)
@@ -48,7 +53,7 @@ end
 obj = kernel();
 obj.name = 'quasiperiodic helmholtz';
 obj.params.zk = zk;
-obj.opdims = [1 1];
+obj.opdims = [numel(kappa) 1];
 
 
 % lattice sum parameters

--- a/chunkie/@kernel/helm2dquas.m
+++ b/chunkie/@kernel/helm2dquas.m
@@ -92,20 +92,24 @@ switch lower(type)
         obj.eval = @(s,t) chnk.helm2dquas.kern(zk, s, t, 's',quas_param);
         obj.fmm = [];
         obj.sing = 'log';
+        if isscalar(kappa)
         obj.splitinfo = [];
         obj.splitinfo.type = {[0 0 0 0],[1 0 0 0]};
         obj.splitinfo.action = {'r','r'};
         obj.splitinfo.functions = @(s,t) helm2dquas_s_split(zk,s,t,quas_param);
+        end
 
     case {'d', 'double'}
         obj.type = 'd';
         obj.eval = @(s,t) chnk.helm2dquas.kern(zk, s, t, 'd',quas_param);
         obj.fmm = [];
         obj.sing = 'log';
+        if isscalar(kappa)
         obj.splitinfo = [];
         obj.splitinfo.type = {[0 0 0 0],[1 0 0 0],[0 0 -1 0]};
         obj.splitinfo.action = {'r','r','r'};
         obj.splitinfo.functions = @(s,t) helm2dquas_d_split(zk,s,t,quas_param);
+        end
 
     case {'sp', 'sprime'}
         obj.type = 'sp';
@@ -129,10 +133,12 @@ switch lower(type)
         obj.eval = @(s,t) chnk.helm2dquas.kern(zk, s, t, 'c',quas_param, coefs);
         obj.fmm = [];
         obj.sing = 'log';
+        if isscalar(kappa)
         obj.splitinfo = [];
         obj.splitinfo.type = {[0 0 0 0],[1 0 0 0],[0 0 -1 0]};
         obj.splitinfo.action = {'r','r','r'};
         obj.splitinfo.functions = @(s,t) helm2dquas_c_split(zk,s,t,quas_param,coefs);
+        end
 
     case {'cp', 'cprime'}
         if ( nargin < 3 )

--- a/devtools/test/quasiperiodicTest.m
+++ b/devtools/test/quasiperiodicTest.m
@@ -7,7 +7,7 @@ function quasiperiodicTest0()
 % problem parameters
 d= 1;
 zk = 1;
-kappa = pi-0.1-1i;
+kappa = [pi-0.1-1i,0.2];
 coefs = [1;0.5];
 coefa = [1,0.3;-1i,0.2];
 
@@ -60,15 +60,19 @@ c2trval = c2trkern.eval(src,targ);
 % test quasiperiodicitiy
 targ_s = targ; targ_s.r = targ.r + [d;0];
 svalshift = skern.eval(src,targ_s);
-assert(abs(svalshift - exp(1i*kappa*d)*sval) <  1e-12)
+assert(norm(svalshift - exp(1i*kappa(:)*d).*sval) <  1e-12)
 
 % test combined
-assert(abs((coefs(1)*dval + coefs(2)*sval)-cval) <  1e-12)
-assert(abs((coefs(1)*dpval + coefs(2)*spval)-cpval) <  1e-12)
+assert(norm((coefs(1)*dval + coefs(2)*sval)-cval) <  1e-12)
+assert(norm((coefs(1)*dpval + coefs(2)*spval)-cpval) <  1e-12)
 
 % test all
-assert(norm([coefa(1,1)*dval, coefa(1,2)*sval; coefa(2,1)*dpval, ...
-    coefa(2,2)*spval] - allval) <  1e-12)
+all_assemb = zeros(size(allval));
+all_assemb(1:2:end, 1:2:end) = coefa(1,1)*dval;
+all_assemb(1:2:end, 2:2:end) = coefa(1,2)*sval;
+all_assemb(2:2:end, 1:2:end) = coefa(2,1)*dpval;
+all_assemb(2:2:end, 2:2:end) = coefa(2,2)*spval;
+assert(norm(all_assemb - allval) <  1e-12)
 
 % test transmission representiatoon
 assert(norm([coefs(1)*dval , coefs(2)*sval]-trval) <  1e-12)
@@ -79,7 +83,10 @@ assert(norm((coefs(1)*dgval + coefs(2)*sgval)-cgval) <  1e-12)
 assert(norm([coefs(1)*dgval , coefs(2)*sgval]-trgval) <  1e-12)
 
 % test c2trans
-assert(norm([coefs(1)*dval + coefs(2)*sval; coefs(1)*dpval + coefs(2)*spval]-c2trval) <  1e-12)
+c2trval_assemb = zeros(size(c2trval));
+c2trval_assemb(1:2:end, :) = coefs(1)*dval + coefs(2)*sval;
+c2trval_assemb(2:2:end, :) = coefs(1)*dpval + coefs(2)*spval;
+assert(norm(c2trval_assemb-c2trval) <  1e-12)
 end
 
 


### PR DESCRIPTION
I fixed a bug in the explicit use quasiperiodicity of the quasiperiodic kernels. The calculation is now stable fairly far out in x.

I also added support for simultaneously handling several kappas (quasiperiodic phases), which greatly accelerates Floquet-Bloch calculations like Agocs and Barnett (2024).