### PR TITLE
Update shape of vector valued quasiperiodic kernels

### DIFF
--- a/chunkie/+chnk/+helm2d/kern.m
+++ b/chunkie/+chnk/+helm2d/kern.m
@@ -40,7 +40,7 @@ function submat= kern(zk,srcinfo,targinfo,type,varargin)
 %                       [coef(1,1)*D coef(1,2)*S; coef(2,1)*D' coef(2,2)*S']
 %                type == 'c2trans' returns the combined field, and the 
 %                          normal derivative of the combined field
-%                        [coef(1)*D + coef(2)*S; coef(1)*D' + coef(2)*S']
+%                        [coef(1,1)*D + coef(1,2)*S; coef(2,1)*D' + coef(2,2)*S']
 %                type == 'trans_rep' returns the potential corresponding
 %                           to the transmission representation
 %                        [coef(1)*D coef(2)*S]
@@ -250,6 +250,7 @@ end
 if strcmpi(type,'c2trans') 
   coef = ones(2,1);
   if(nargin == 5); coef = varargin{1}; end
+  if numel(coef) == 2, coef = repmat(coef(:).',2,1); end
   targnorm = targinfo.n(:,:);
   srcnorm = srcinfo.n(:,:);
 
@@ -272,8 +273,8 @@ if strcmpi(type,'c2trans')
 
   submat = zeros(2*nt,ns);
 
-  submat(1:2:2*nt,:) = coef(1)*submatd + coef(2)*submats;
-  submat(2:2:2*nt,:) = coef(1)*submatdp + coef(2)*submatsp;
+  submat(1:2:2*nt,:) = coef(1,1)*submatd + coef(1,2)*submats;
+  submat(2:2:2*nt,:) = coef(2,1)*submatdp + coef(2,2)*submatsp;
 
 end
 

--- a/chunkie/+chnk/+helm2dquas/green.m
+++ b/chunkie/+chnk/+helm2dquas/green.m
@@ -95,7 +95,6 @@ val_near=0;
 grad_near = zeros(1,1,2);
 hess_near = zeros(1,1,3);
 if ~isempty(rxclose)
-    ls = [-l:-1, 1:l];
     ls = -l:l;
     for i = ls
         rxi = rxclose - i*d;

--- a/chunkie/+chnk/+helm2dquas/green.m
+++ b/chunkie/+chnk/+helm2dquas/green.m
@@ -1,5 +1,5 @@
 function [val,grad,hess] = green(src,targ,zk,kappa,d,sn,l)
-%CHNK.HELM2DQUAS.GREEN evaluate the quasiperiodic helmholtz green's function
+%CHNK.HELM2DQUAS.GREEN evaluate the quasiperiodic Helmholtz Green's function
 % for the given sources and targets
 %
 % Input:
@@ -12,7 +12,6 @@ function [val,grad,hess] = green(src,targ,zk,kappa,d,sn,l)
 % see also CHNK.HELM2DQUAS.KERN
 [~,nsrc] = size(src);
 [~,ntarg] = size(targ);
-
 
 xs = repmat(src(1,:),ntarg,1);
 ys = repmat(src(2,:),ntarg,1);
@@ -40,8 +39,7 @@ r = r(:);
 
 npt = size(r,1);
 
-ythresh = d/2;
-% ythresh = d/10;
+ythresh = 2*d/2;
 iclose = abs(ry) < ythresh;
 ifar = ~iclose;
 
@@ -76,22 +74,18 @@ xi_m = kappa(:) + 2*pi/d*ms;
 % beta = sqrt((xi_m.^2-zk^2));
 beta = sqrt(1i*(xi_m-zk)).*sqrt(-1i*(xi_m+zk));
 
-% fhat = exp(-beta.*sqrt(ryfar.^2))./beta.*exp(1i*xi_m.*rxfar)/2;
 fhat = exp(-beta.*sqrt(ryfar.^2) + 1i*xi_m.*rxfar)./(2*beta);
 val(:,ifar,:) = sum(fhat,3)/(d);
 if nargout > 1
 grad(:,ifar,1) = sum(1i*xi_m.*fhat,3)/d;
 grad(:,ifar,2) = sum(-beta.*(sqrt(ryfar.^2)./ryfar).*fhat,3)/d;
-% grad(:,ifar,:) =[gx,gy];
 end
 
 if nargout >2
 hess(:,ifar,1) = sum(-xi_m.^2.*fhat,3)/d;
 hess(:,ifar,2) = sum(-1i*xi_m.*beta.*(sqrt(ryfar.^2)./ryfar).*fhat,3)/d;
 hess(:,ifar,3) = sum((beta.*(sqrt(ryfar.^2)./ryfar)).^2.*fhat,3)/d;
-% hess(:,ifar,:) = [hxx,hxy,hyy];
 end
-
 
 end
 
@@ -101,7 +95,9 @@ val_near=0;
 grad_near = zeros(1,1,2);
 hess_near = zeros(1,1,3);
 if ~isempty(rxclose)
-    for i = -l:l
+    ls = [-l:-1, 1:l];
+    ls = -l:l;
+    for i = ls
         rxi = rxclose - i*d;
         if nargout>2
         [vali,gradi,hessi] = chnk.helm2d.green(zk,[0;0],[rxi.';ryclose.']);
@@ -123,8 +119,7 @@ if ~isempty(rxclose)
         val_near = val_near + vali.*alpha.^i;
         end
     end
-    
-    % sn = sn.';
+
     N = size(sn,2)-1;
     ns = (0:N);
     ns_use = (0:N+2);
@@ -148,9 +143,6 @@ if ~isempty(rxclose)
     
     val_far = 0.25*1i*Js(:,:,1).*sn(:,:,1) + 0.5*1i*sum(sn(:,:,2:end).*Js(:,:,2:end-2).*cs(:,:,2:end),3);
     val(:,iclose) = val_near+val_far;
-    
-    
-    
     
     if nargout >1
         DJs = cat(3,-Js(:,:,2),.5*(Js(:,:,1:end-3)-Js(:,:,3:end-1)))*zk;
@@ -202,7 +194,5 @@ end
 if nargout>2
 hess = reshape(quasi_phase.*hess,nkappa*ntarg,nsrc,3);
 end
-% end
-
 end
 

--- a/chunkie/@kernel/helm2dquas.m
+++ b/chunkie/@kernel/helm2dquas.m
@@ -60,7 +60,7 @@ obj.opdims = [numel(kappa) 1];
 l=2; N = 40; a = 15; M = 1e4;
 
 if nargin == 6
-    if isefield(quad_opts,'l')
+    if isfield(quad_opts,'l')
         l = quad_opts.l;
     end
     if isfield(quad_opts,'N')
@@ -82,11 +82,6 @@ quas_param.kappa = kappa;
 quas_param.d = d;
 quas_param.l = l;
 quas_param.sn = sn;
-
-% obj.params.kappa = kappa;
-% obj.params.d = d;
-% obj.params.l = l;
-% obj.params.Sn = Sn;
 
 obj.params.quas_param = quas_param;
 
@@ -160,7 +155,6 @@ switch lower(type)
         error('Unknown Helmholtz kernel type ''%s''.', type);
 
 end
-
 end
 
 function f = helm2dquas_s_split(zk,s,t,quas_param)

--- a/devtools/test/quasiperiodicTest.m
+++ b/devtools/test/quasiperiodicTest.m
@@ -68,10 +68,10 @@ assert(norm((coefs(1)*dpval + coefs(2)*spval)-cpval) <  1e-12)
 
 % test all
 all_assemb = zeros(size(allval));
-all_assemb(1:2:end, 1:2:end) = coefa(1,1)*dval;
-all_assemb(1:2:end, 2:2:end) = coefa(1,2)*sval;
-all_assemb(2:2:end, 1:2:end) = coefa(2,1)*dpval;
-all_assemb(2:2:end, 2:2:end) = coefa(2,2)*spval;
+all_assemb(1:2, 1:2:end) = coefa(1,1)*dval;
+all_assemb(1:2, 2:2:end) = coefa(1,2)*sval;
+all_assemb(3:end, 1:2:end) = coefa(2,1)*dpval;
+all_assemb(3:end, 2:2:end) = coefa(2,2)*spval;
 assert(norm(all_assemb - allval) <  1e-12)
 
 % test transmission representiatoon
@@ -84,8 +84,8 @@ assert(norm([coefs(1)*dgval , coefs(2)*sgval]-trgval) <  1e-12)
 
 % test c2trans
 c2trval_assemb = zeros(size(c2trval));
-c2trval_assemb(1:2:end, :) = coefs(1)*dval + coefs(2)*sval;
-c2trval_assemb(2:2:end, :) = coefs(1)*dpval + coefs(2)*spval;
+c2trval_assemb(1:2, :) = coefs(1)*dval + coefs(2)*sval;
+c2trval_assemb(3:end, :) = coefs(1)*dpval + coefs(2)*spval;
 assert(norm(c2trval_assemb-c2trval) <  1e-12)
 end
 
@@ -97,7 +97,7 @@ function quasiperiodicTest1()
 % problem parameters
 d= 8;
 zk = 1;
-kappa = .05+0.1i;
+kappa = .05+.1i;
 
 % setup geometry
 nch = 2^3;


### PR DESCRIPTION
Reordered the vector valued quasiperiodic kernels so that the shape is (nkappa, opdim(1) nt, opdim(2) ns), which makes it easier to integrate in kappa.

Also enabled more general coefficients in the 'c2trans' Helmholtz kernel. This allows us to return [a u; b du/dn] and fits the format of the other transmission kernels.