### PR TITLE
Fix edge region identification by converting cell to matrix

### DIFF
--- a/chunkie/@chunkgraph/find_edge_regions.m
+++ b/chunkie/@chunkgraph/find_edge_regions.m
@@ -21,7 +21,7 @@ function edge_regs = find_edge_regions(obj)
     edge_regs = zeros(2,size(obj.edgesendverts,2));
     nreg = length(obj.regions);
     for i = 1:nreg
-        id_edge = obj.regions{i}{1};
+        id_edge = cell2mat(obj.regions{i});
         edge_regs(1,id_edge(id_edge>0)) = i;
         edge_regs(2,-id_edge(id_edge<0)) = i;
     end

--- a/devtools/test/chunkgrphregionTest.m
+++ b/devtools/test/chunkgrphregionTest.m
@@ -82,7 +82,14 @@ for i = 1:7
    end
 end
 
-
+edgereg = find_edge_regions(cgrph);
+for i = 1:7
+    edges = cell2mat(rgntrue{i});
+    assert(all(edgereg(1,edges(edges>0)) == i))
+    assert(all(edgereg(2,abs(edges(edges<0))) == i))
+end
+assert(min(edgereg(:))==1)
+assert(max(edgereg(:))==length(cgrph.regions))
 
 end
 


### PR DESCRIPTION
The function that returns the region on each side of a chunkgraph edge broke when there were multiple disjoint obstacles, e.g. if we computed the scattering from several squares.