### PR TITLE
Set MATLAB as the linguist language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.m linguist-language=MATLAB


### PR DESCRIPTION
Add `.gitattributes` with `*.m linguist-language=MATLAB` so GitHub's Linguist classifies the repo as MATLAB instead of Wolfram Language (the `.m` extension is ambiguous between MATLAB / Objective-C / Mathematica / Wolfram, and Linguist's heuristics were guessing wrong).