### PR TITLE
Kernel-split (wLCHS) quadrature framework + Laplace S/D/Sp/Dp

### DIFF
--- a/chunkie/+chnk/+kernsplit/lap2d_adj_correction.m
+++ b/chunkie/+chnk/+kernsplit/lap2d_adj_correction.m
@@ -1,0 +1,128 @@
+function [delta, U_src_cell] = lap2d_adj_correction(chnkr, type, U_src_cell)
+%CHNK.HELSINGO.LAP2D_ADJ_CORRECTION  adjacent-panel close-correction
+% delta for a 2D Laplace layer-potential system matrix.
+%
+% Returns a sparse npt x npt matrix whose adjacent-panel entries are the
+% delta from smooth Gauss-Legendre quadrature.  Self and far entries are
+% zero; only adjacent pairs are populated.
+%
+% Mirrors `helm2d_adj_correction` with the zk -> 0 limit of helm2d_close
+% (J_0 -> 1, J_1, J_2 contributions vanish).
+%
+% Supported types: 's', 'd', 'sp', 'dp'.
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+npt = chnkr.npt;
+tlow = lower(type);
+if ~ismember(tlow, {'s','single','d','double','sp','sprime','dp','dprime'})
+    delta = sparse(npt, npt);
+    if nargout > 1, U_src_cell = {}; end
+    return
+end
+
+if nargin < 3 || isempty(U_src_cell), U_src_cell = cell(1, nch); end
+
+[T_GL, wgl, U_GL_panel] = lege.exps(ngl);
+P_left  = (-1).^(0:ngl-1);
+P_right = ones(1, ngl);
+
+[rends, ~] = chunkends(chnkr);
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));
+
+% per-panel endpoint speed (for adjacent-panel alpha)
+speed_left  = zeros(nch, 1);
+speed_right = zeros(nch, 1);
+for ip = 1:nch
+    di = chnkr.d(:, :, ip);
+    cdi = U_GL_panel * (di.');
+    dleft  = P_left  * cdi;
+    dright = P_right * cdi;
+    speed_left(ip)  = norm(dleft);
+    speed_right(ip) = norm(dright);
+end
+
+ii = []; jj = []; vv = [];
+
+for ip_src = 1:nch
+    src_idx = (ip_src-1)*ngl + (1:ngl);
+    zsrc = chnkr.r(1,:,ip_src) + 1i*chnkr.r(2,:,ip_src);
+    nz_s = chnkr.n(1,:,ip_src) + 1i*chnkr.n(2,:,ip_src);
+    d_s  = chnkr.d(1,:,ip_src) + 1i*chnkr.d(2,:,ip_src);
+    wzp  = d_s .* wgl(:).';
+    awzp = chnkr.wts(:, ip_src).';
+    a = endsa(ip_src);
+    b = endsb(ip_src);
+
+    if isempty(U_src_cell{ip_src})
+        U_src_cell{ip_src} = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc);
+    end
+    U_src = U_src_cell{ip_src};
+
+    for side = [1, 2]
+        ip_tgt = chnkr.adj(side, ip_src);
+        if ip_tgt <= 0; continue; end
+
+        tgt_idx = (ip_tgt-1)*ngl + (1:ngl);
+        ztgt = (chnkr.r(1,:,ip_tgt) + 1i*chnkr.r(2,:,ip_tgt)).';
+        nzt  = (chnkr.n(1,:,ip_tgt) + 1i*chnkr.n(2,:,ip_tgt)).';
+
+        if side == 1
+            alpha = speed_right(ip_tgt) / speed_left(ip_src);
+            trans = -1 - alpha;
+        else
+            alpha = speed_left(ip_tgt) / speed_right(ip_src);
+            trans = 1 + alpha;
+        end
+        mscale = alpha;
+
+        [WfrakL, accept] = chnk.kernsplit.wfrak_log(ngl, trans, mscale);
+        if isempty(accept); continue; end
+
+        T_acc = T_GL(accept);
+        if side == 1
+            Ta = T_GL + 1;
+            Tb = (1 - T_acc) * alpha;
+            log_smooth = log(abs(Ta.' + Tb));
+        else
+            Ta = T_GL - 1;
+            Tb = (T_acc + 1) * alpha;
+            log_smooth = log(abs(Ta.' - Tb));
+        end
+        LogC_w = WfrakL ./ wgl(:).' - log_smooth;
+        LogC_full = zeros(ngl, ngl);
+        LogC_full(accept, :) = LogC_w;
+
+        % Per-type moment computation
+        switch tlow
+            case {'s','single'}
+                Mc = chnk.kernsplit.lap2d_close('s', ztgt, zsrc, nz_s, ...
+                                                wzp, LogC_full);
+                Mblk = Mc .* awzp;
+            case {'d','double'}
+                [~, CauC_full] = chnk.kernsplit.wlchs_target( ...
+                    a, b, ztgt, zsrc, nz_s, wzp, awzp, U_src, 0);
+                Mblk = chnk.kernsplit.lap2d_close('d', ztgt, zsrc, ...
+                    nz_s, wzp, LogC_full, CauC_full);
+            case {'sp','sprime'}
+                [~, CauC_full] = chnk.kernsplit.wlchs_target( ...
+                    a, b, ztgt, zsrc, nz_s, wzp, awzp, U_src, 0);
+                Mblk = chnk.kernsplit.lap2d_close('sp', ztgt, zsrc, ...
+                    nz_s, wzp, LogC_full, CauC_full, [], nzt);
+            case {'dp','dprime'}
+                [~, ~, HypC_full] = chnk.kernsplit.wlchs_target( ...
+                    a, b, ztgt, zsrc, nz_s, wzp, awzp, U_src, 0);
+                Mblk = chnk.kernsplit.lap2d_close('dp', ztgt, zsrc, ...
+                    nz_s, wzp, LogC_full, [], HypC_full, nzt);
+        end
+
+        [I, J] = ndgrid(tgt_idx, src_idx);
+        ii = [ii; I(:)];
+        jj = [jj; J(:)];
+        vv = [vv; Mblk(:)];
+    end
+end
+
+delta = sparse(ii, jj, vv, npt, npt);
+end

--- a/chunkie/+chnk/+kernsplit/lap2d_close.m
+++ b/chunkie/+chnk/+kernsplit/lap2d_close.m
@@ -1,0 +1,80 @@
+function M = lap2d_close(type, ztrg, zsrc, nz, wzp, LogC, CauC, HypC, nzt, awzp)
+%CHNK.HELSINGO.LAP2D_CLOSE  close-evaluation correction matrices for 2D
+% Laplace layer potentials, in the kernel-split style of Helsing & Ojala.
+%
+% Conventions (chunkie's): G = -log|r|/(2*pi); n_y is outward-pointing
+% complex normal at source; |dy| = arclength element.
+%
+% Layer types implemented:
+%   's'/'single'   - SLP   S(tau)(x) = -1/(2pi) integral log|x-y| tau ds
+%   'd'/'double'   - DLP   D(tau)(x) =  1/(2pi) integral (n_y . (x-y))/r^2 tau ds
+%   'sp'/'sprime'  - normal derivative of SLP at target
+%   'dp'/'dprime'  - normal derivative of DLP at target (hypersingular)
+%
+% Output convention follows helm2d_close: M*density gives the close-
+% evaluated layer potential at targets, EXCEPT for 's' where the caller
+% multiplies in awzp externally (i.e. M*(awzp.*density)).
+%
+% Inputs:
+%   type  - 's'/'single', 'd'/'double', 'sp'/'sprime', 'dp'/'dprime'.
+%   ztrg  - nt x 1 complex target points.
+%   zsrc  - 1 x Ng complex source nodes.
+%   nz    - 1 x Ng complex unit normals at sources (for 'd', 'dp').
+%   wzp   - 1 x Ng complex contour weights z'(t)*w_GL (for sp/dp).
+%   LogC  - nt x Ng log-singular correction from wlchs_target.
+%   CauC  - nt x Ng Cauchy correction from wlchs_target ('d', 'sp').
+%   HypC  - nt x Ng hypersingular correction ('dp').
+%   nzt   - nt x 1 complex target normals ('sp', 'dp').
+%   awzp  - 1 x Ng real arclength weights ('dp', baked into LogC piece).
+%
+% Output:
+%   M     - nt x Ng correction matrix.
+
+switch lower(type)
+    case {'s','single'}
+        % S = -log|r|/(2pi).  Per derivation: M = -LogC/(2pi) and caller
+        % multiplies M*(awzp.*density) externally.
+        M = -LogC/(2*pi);
+
+    case {'d','double'}
+        % D = (1/2pi) Re(n_y/(z-w)).  Cauchy moment 1i*CauC corresponds to
+        % I_C correction; its real part divided by 2pi (with sign) is the
+        % matrix correction.  Verified by zk -> 0 limit of helm2d_close.
+        if nargin < 7 || isempty(CauC)
+            error('CHNK.HELSINGO.LAP2D_CLOSE: ''d'' requires CauC');
+        end
+        M = -real(CauC)/(2*pi);
+
+    case {'sp','sprime'}
+        % S' = n_x . grad_x S = (1/2pi) Re(n_x * I_C[tau/(in_y)]).  The
+        % wcmpC delta moment for source g = tau/(in_y) is wcmpC[i,j]/nz_j,
+        % so the correction is:
+        %   M_correction = (1/2pi) Re( n_x_i * wcmpC[i,j] / nz_j )
+        if nargin < 7 || isempty(CauC)
+            error('CHNK.HELSINGO.LAP2D_CLOSE: ''sp'' requires CauC');
+        end
+        if nargin < 9 || isempty(nzt)
+            error('CHNK.HELSINGO.LAP2D_CLOSE: ''sp'' requires target normals nzt');
+        end
+        nzt = nzt(:);
+        nz  = nz(:).';
+        M = real(nzt .* (CauC ./ nz)) / (2*pi);
+
+    case {'dp','dprime'}
+        % D' = -(1/2pi) Im( n_x I_H(tau)(x) ).  Direct zk->0 limit of
+        % helm2d_close 'dp': the Mlog piece vanishes (zk^2 prefactor),
+        % leaving M = -Re(n_x .* HypC) / (2*pi).  HypC already has
+        % source weights baked in via wlchs_target's thyp.
+        if nargin < 8 || isempty(HypC)
+            error('CHNK.HELSINGO.LAP2D_CLOSE: ''dp'' requires HypC');
+        end
+        if nargin < 9 || isempty(nzt)
+            error('CHNK.HELSINGO.LAP2D_CLOSE: ''dp'' requires target normals nzt');
+        end
+        nzt = nzt(:);
+        M = -real(nzt .* HypC) / (2*pi);
+
+    otherwise
+        error('CHNK.HELSINGO.LAP2D_CLOSE: unsupported type %s', type);
+end
+end

--- a/chunkie/+chnk/+kernsplit/lap2d_panel_eval.m
+++ b/chunkie/+chnk/+kernsplit/lap2d_panel_eval.m
@@ -1,0 +1,125 @@
+function val = lap2d_panel_eval(chnkr, type, dens, targets, dlim, eval_opts)
+%CHNK.HELSINGO.LAP2D_PANEL_EVAL  off-curve evaluation of Laplace layer
+% potentials with kernel-split close correction (Helsing-Ojala / wLCHS).
+%
+% Conventions: chunkie's S = -log|r|/(2*pi); n_y outward complex normal.
+%
+% Inputs:
+%   chnkr   - chunker (single connected sequence of panels).
+%   type    - 's'/'single', 'd'/'double', 'sp'/'sprime' (target-normal
+%             derivative of S; requires target normals via struct input).
+%   dens    - chnkr.npt x 1 density samples at chunker nodes.
+%   targets - 2 x nt real target locations, OR struct with fields .r
+%             (2 x nt) and .n (2 x nt) target normals (required for 'sp').
+%   dlim    - (optional, default 1.1) close-target threshold.
+%   eval_opts - struct with optional opts.forcefmm passed through to
+%               chunkerkerneval for the smooth far-field evaluation.
+
+if nargin < 5 || isempty(dlim); dlim = 1.1; end
+if nargin < 6; eval_opts = []; end
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+
+% Normalize targets spec
+if isstruct(targets)
+    targ_r = targets.r;
+    if isfield(targets,'n'), targ_n = targets.n; else, targ_n = []; end
+else
+    targ_r = targets;
+    targ_n = [];
+end
+
+zsrc_all = (chnkr.r(1,:,:) + 1i*chnkr.r(2,:,:));
+zsrc_all = zsrc_all(:).';
+nz_all   = (chnkr.n(1,:,:) + 1i*chnkr.n(2,:,:));
+nz_all   = nz_all(:).';
+[~, wgl] = lege.exps(ngl);
+awzp_all = chnkr.wts(:).';
+d_all    = (chnkr.d(1,:,:) + 1i*chnkr.d(2,:,:));
+d_all    = d_all(:).';
+wgl_rep  = repmat(wgl(:).', 1, nch);
+wzp_all  = d_all .* wgl_rep;
+ztgt = targ_r(1,:).' + 1i*targ_r(2,:).';
+dens = dens(:);
+if ~isempty(targ_n)
+    nzt_all = (targ_n(1,:) + 1i*targ_n(2,:)).';
+else
+    nzt_all = [];
+end
+
+% Smooth far-field via chunkerkerneval (FMM-able; avoids dense alloc).
+tlow = lower(type);
+needs_tgt_normals = any(strcmp(tlow, {'sp','sprime'}));
+if needs_tgt_normals && isempty(targ_n)
+    error(['CHNK.HELSINGO.LAP2D_PANEL_EVAL: type ''sp'' requires target ' ...
+           'normals; pass targets as struct with .n field']);
+end
+switch tlow
+    case {'s','single'},   ker = kernel('lap','s');
+    case {'d','double'},   ker = kernel('lap','d');
+    case {'sp','sprime'},  ker = kernel('lap','sp');
+    otherwise
+        error('CHNK.HELSINGO.LAP2D_PANEL_EVAL: unknown type %s', type);
+end
+ck_opts = struct('forcesmooth', true);
+if isstruct(eval_opts) && isfield(eval_opts,'forcefmm') && eval_opts.forcefmm
+    ck_opts.forcefmm = true;
+end
+if needs_tgt_normals
+    val = chunkerkerneval(chnkr, ker, dens, struct('r',targ_r,'n',targ_n), ck_opts);
+else
+    val = chunkerkerneval(chnkr, ker, dens, targ_r, ck_opts);
+end
+
+% Per-panel close correction
+[rends,~] = chunkends(chnkr);
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));
+panlen = zeros(nch,1);
+for ip = 1:nch
+    panlen(ip) = sum(awzp_all((ip-1)*ngl+(1:ngl)));
+end
+dlim2 = dlim^2;
+
+for ip = 1:nch
+    pidx = (ip-1)*ngl + (1:ngl);
+    zsrc_p = zsrc_all(pidx);
+    nz_p   = nz_all(pidx);
+    wzp_p  = wzp_all(pidx);
+    awzp_p = awzp_all(pidx);
+    a = endsa(ip); b = endsb(ip);
+
+    diff_p = ztgt - zsrc_p;
+    d2_p   = real(diff_p).*real(diff_p) + imag(diff_p).*imag(diff_p);
+    near   = min(d2_p, [], 2) < dlim2*panlen(ip)^2;
+    if ~any(near); continue; end
+
+    ztgt_near = ztgt(near);
+    U = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc_p);
+
+    switch lower(type)
+        case {'s','single'}
+            LogC = chnk.kernsplit.wlchs_target(a, b, ztgt_near, zsrc_p, ...
+                nz_p, wzp_p, awzp_p, U, 0);
+            Mclose = chnk.kernsplit.lap2d_close('s', ztgt_near, zsrc_p, ...
+                nz_p, wzp_p, LogC, []);
+            val(near) = val(near) + Mclose * (awzp_p(:).*dens(pidx));
+
+        case {'d','double'}
+            [LogC, CauC] = chnk.kernsplit.wlchs_target(a, b, ztgt_near, ...
+                zsrc_p, nz_p, wzp_p, awzp_p, U, 0);
+            Mclose = chnk.kernsplit.lap2d_close('d', ztgt_near, zsrc_p, ...
+                nz_p, wzp_p, LogC, CauC);
+            val(near) = val(near) + Mclose * dens(pidx);
+
+        case {'sp','sprime'}
+            [LogC, CauC] = chnk.kernsplit.wlchs_target(a, b, ztgt_near, ...
+                zsrc_p, nz_p, wzp_p, awzp_p, U, 0);
+            nzt_near = nzt_all(near);
+            Mclose = chnk.kernsplit.lap2d_close('sp', ztgt_near, zsrc_p, ...
+                nz_p, wzp_p, LogC, CauC, [], nzt_near);
+            val(near) = val(near) + Mclose * dens(pidx);
+    end
+end
+end

--- a/chunkie/+chnk/+kernsplit/lap2d_self_correction.m
+++ b/chunkie/+chnk/+kernsplit/lap2d_self_correction.m
@@ -1,0 +1,95 @@
+function [delta, U_src_cell] = lap2d_self_correction(chnkr, type, U_src_cell)
+%CHNK.HELSINGO.LAP2D_SELF_CORRECTION  self-panel close-correction for 2D
+% Laplace layer potentials (Helsing-Ojala / wLCHS).
+%
+% Returns a sparse matrix `delta` whose diagonal entries are the FULL
+% close-evaluated matrix entry, and off-diagonal entries are the kernel
+% delta over smooth Gauss-Legendre quadrature.  The caller (chunkermat
+% wlchs path) supplies M_smooth with diag zeroed; M_smooth + delta is
+% then the full close-evaluated self block.
+%
+% Mirrors the zk -> 0 limit of helm2d_self_correction.
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+npt = chnkr.npt;
+tlow = lower(type);
+if ~ismember(tlow, {'s','single','d','double','sp','sprime','dp','dprime'})
+    delta = sparse(npt, npt);
+    return
+end
+
+if nargin < 3 || isempty(U_src_cell), U_src_cell = cell(1, nch); end
+
+[T, wgl] = lege.exps(ngl);
+[WfrakL, accept] = chnk.kernsplit.wfrak_log(ngl, 0, 1);
+if numel(accept) ~= ngl
+    error('lap2d_self_correction: self log moments should accept all GL nodes');
+end
+LogC0 = -log(abs(T(:) - T(:).'));
+LogC0(1:ngl+1:end) = 0;
+LogC0 = LogC0 + WfrakL ./ wgl(:).';
+
+[rends, ~] = chunkends(chnkr);
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));
+
+ii = []; jj = []; vv = [];
+for ip = 1:nch
+    idx = (ip-1)*ngl + (1:ngl);
+    zsrc = chnkr.r(1,:,ip) + 1i*chnkr.r(2,:,ip);
+    nz   = chnkr.n(1,:,ip) + 1i*chnkr.n(2,:,ip);
+    dz   = chnkr.d(1,:,ip) + 1i*chnkr.d(2,:,ip);
+    awzp = chnkr.wts(:,ip).';
+    wzp  = dz .* wgl(:).';
+    logspd = log(abs(dz));
+    a = endsa(ip); b = endsb(ip);
+
+    ztgt = zsrc(:); nzt = nz(:);
+
+    switch tlow
+        case {'s','single'}
+            % off-diag: M = -LogC0/(2*pi) * awzp  (matches zk->0 of helm)
+            % diag:    M = -(log|dz| + diag(LogC0))/(2*pi) * awzp
+            Mblk = -LogC0/(2*pi);
+            Mblk = Mblk .* awzp;
+            dval = -(logspd + diag(LogC0).')/(2*pi) .* awzp;
+            Mblk(1:ngl+1:end) = dval;
+
+        case {'d','double'}
+            % Laplace D self block: needs CauC moment (wlchs_target self)
+            if isempty(U_src_cell{ip})
+                U_src_cell{ip} = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc);
+            end
+            U = U_src_cell{ip};
+            [~, CauC] = chnk.kernsplit.wlchs_target(a, b, ztgt, zsrc, ...
+                nz, wzp, awzp, U, 1);
+            Mblk = chnk.kernsplit.lap2d_close('d', ztgt, zsrc, nz, wzp, ...
+                LogC0, CauC);
+
+        case {'sp','sprime'}
+            if isempty(U_src_cell{ip})
+                U_src_cell{ip} = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc);
+            end
+            U = U_src_cell{ip};
+            [~, CauC] = chnk.kernsplit.wlchs_target(a, b, ztgt, zsrc, ...
+                nz, wzp, awzp, U, 1);
+            Mblk = chnk.kernsplit.lap2d_close('sp', ztgt, zsrc, nz, wzp, ...
+                LogC0, CauC, [], nzt);
+
+        case {'dp','dprime'}
+            if isempty(U_src_cell{ip})
+                U_src_cell{ip} = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc);
+            end
+            U = U_src_cell{ip};
+            [~, ~, HypC] = chnk.kernsplit.wlchs_target(a, b, ztgt, zsrc, ...
+                nz, wzp, awzp, U, 1);
+            Mblk = chnk.kernsplit.lap2d_close('dp', ztgt, zsrc, nz, wzp, ...
+                LogC0, [], HypC, nzt);
+    end
+
+    [I, J] = ndgrid(idx, idx);
+    ii = [ii; I(:)]; jj = [jj; J(:)]; vv = [vv; Mblk(:)];
+end
+delta = sparse(ii, jj, vv, npt, npt);
+end

--- a/chunkie/+chnk/+kernsplit/mydepth.m
+++ b/chunkie/+chnk/+kernsplit/mydepth.m
@@ -1,0 +1,20 @@
+function y = mydepth(zsctr,x,Ng)
+%CHNK.HELSINGO.MYDEPTH  evaluate a polynomial that interpolates the
+% imaginary parts of the recentered source nodes (with imag=0 forced at
+% +/-1) at a real query point x.
+%
+% Used by wlchs_target to detect the convex/concave panel exception
+% when deciding whether a target lies on the "left" or "right" of the
+% complexified contour.
+
+A  = ones(Ng+2);
+xx = [-1; real(zsctr(:)); 1];
+for k = 2:Ng+2
+    A(:,k) = xx.*A(:,k-1);
+end
+coeff = A \ [0; imag(zsctr(:)); 0];
+y = coeff(Ng+2);
+for k = Ng+1:-1:1
+    y = y*x + coeff(k);
+end
+end

--- a/chunkie/+chnk/+kernsplit/wfrak_log.m
+++ b/chunkie/+chnk/+kernsplit/wfrak_log.m
@@ -1,0 +1,66 @@
+function [WfrakL, accept] = wfrak_log(ngl, trans, mscale)
+%CHNK.HELSINGO.WFRAK_LOG  parameter-space log-moment correction for an
+% adjacent-panel pair, used by the kernel-split close-correction
+% machinery (port of testhelmos's WfrakLinit).
+%
+% This is the right tool when the target points lie ALONG the curve on
+% an immediately-adjacent panel (i.e., on the real-axis continuation of
+% the source panel in the canonical [-1,1] parameter space).  In that
+% setting wlchs_target's complex-log + ifleft branch-cut machinery
+% produces incorrect log moments (cuts cross through real-axis targets);
+% wfrak_log uses a real-valued recurrence instead.  Use wlchs_target for
+% off-curve close eval, and for the hypersingular moment HypC even for
+% on-curve adjacent targets (HypC does not suffer from the same branch
+% cut issue).
+%
+% Inputs:
+%   ngl     - panel order (number of GL nodes per panel).
+%   trans   - canonical-space translation: target-panel midpoint mapped
+%             into source-panel parameter coordinates.  E.g. for the
+%             "superdiagonal" (target panel to the LEFT of source),
+%             trans = -1 - alpha; for "subdiagonal" (target to the RIGHT),
+%             trans = +1 + alpha; where alpha = panel-length ratio.
+%   mscale  - canonical-space scale: alpha (target-to-source size ratio).
+%
+% Outputs:
+%   WfrakL  - na x ngl matrix.  WfrakL(i,j) is the log-moment integral
+%               \int_{-1}^{1} ell_j(s) * log|s - T_i| ds
+%             where ell_j is the Lagrange basis at the j-th source GL
+%             node and T_i = trans + mscale*T_node_i is the i-th
+%             "accepted" target's canonical position in the source frame.
+%   accept  - 1 x na index vector of which target rows had |T_i|<2 (i.e.
+%             which adjacent-panel target nodes are within wLCHS support).
+%             Targets with |T_i|>=2 are treated as far enough that the
+%             smooth GL quadrature is sufficient.
+
+[T_nodes, ~, U_GL] = lege.exps(ngl);     % U_GL: values -> Legendre coeffs (scaled)
+T_nodes = T_nodes(:);
+T_targ  = trans + mscale*T_nodes;
+accept  = find(abs(T_targ) < 2).';
+na = numel(accept);
+
+if na == 0
+    WfrakL = zeros(0, ngl);
+    return;
+end
+
+P = zeros(na, ngl+1);
+Q = zeros(na, ngl);
+c0 = 2*(1:ngl-1) + 1;
+c1 = 1./c0;             % 1/(2k+1)
+c2 = 1./(2:ngl);        % 1/(k+1)
+
+Ta = T_targ(accept);
+upp = log(abs(1 - Ta));
+loo = log(abs(1 + Ta));
+P(:,1) = upp - loo;
+P(:,2) = 2 + Ta.*P(:,1);
+for k = 1:ngl-1
+    P(:,k+2) = (c0(k)*Ta.*P(:,k+1) - k*P(:,k))*c2(k);
+end
+
+Q(:,1) = 2*upp - (Ta+1).*P(:,1) - 2;
+Q(:,2:ngl) = (P(:,1:ngl-1) - P(:,3:ngl+1)).*c1;
+
+WfrakL = Q*U_GL;
+end

--- a/chunkie/+chnk/+kernsplit/wlchs_src_precomp.m
+++ b/chunkie/+chnk/+kernsplit/wlchs_src_precomp.m
@@ -1,0 +1,48 @@
+function U = wlchs_src_precomp(a,b,zsc)
+%CHNK.HELSINGO.WLCHS_SRC_PRECOMP  precompute source-side data for
+% wlchs_target.
+%
+% Inputs (panel parameterized in complex form):
+%   a, b  - complex endpoints of the panel
+%   zsc   - 1 x Ng complex source nodes (Gauss-Legendre on the panel)
+%
+% Output:
+%   U     - Ng x Ng inverse Vandermonde matrix mapping function values at
+%           Legendre nodes to Legendre coefficients.
+%
+% O(p^3) operations.  Reusable across many target points on the same panel.
+
+cc    = (b-a)/2;
+n     = numel(zsc);
+
+% On dyadically-refined panels (RCIP) cc can shrink to ~machine eps.
+% Then (zsc-mid)/cc suffers catastrophic cancellation, zsctr collapses, and
+% inv(p.') is singular.  Mathematically zsctr exactly equals the real
+% Gauss-Legendre nodes for a straight panel and deviates by
+% O(curvature·panel_length) for a smooth curve.  When the panel is so small
+% that no meaningful curvature variation is resolvable (|cc| below
+% sqrt(eps)·char_scale), zsctr is unreliable; use the cached
+% inverse-Vandermonde for canonical GL nodes instead.
+persistent U_cache_real xs_cache n_cache
+if isempty(U_cache_real) || n_cache ~= n
+    [xs_gl, ~, ~, ~] = lege.exps(n);
+    [p_gl, ~] = lege.pols(xs_gl(:), n-1);
+    U_cache_real = inv(p_gl.');
+    xs_cache = xs_gl(:);
+    n_cache = n;
+end
+
+% Fall back to cache when (zsc-mid)/cc would lose precision.  Threshold:
+% cc smaller than ~sqrt(eps) of the panel mid-magnitude → cancellation in
+% (zsc - mid) drops too many digits.  Conservative.
+ref_scale = max(1, abs((b+a)/2));
+use_cache = abs(cc) < 1e-8 * ref_scale;
+
+if use_cache
+    U = U_cache_real;
+else
+    zsctr = (zsc(:) - (b+a)/2)/cc;
+    [p,~] = lege.pols(zsctr, n-1);
+    U = inv(p.');
+end
+end

--- a/chunkie/+chnk/+kernsplit/wlchs_target.m
+++ b/chunkie/+chnk/+kernsplit/wlchs_target.m
@@ -1,0 +1,148 @@
+function [wcmpL,wcmpC,wcmpH,wcmpS] = wlchs_target(a,b,ztg,zsc,nz,wzp,awzp,U,ifself)
+%CHNK.HELSINGO.WLCHS_TARGET  panel-quadrature corrections (log, Cauchy,
+% hypersingular, supersingular) for one panel and a vector of target
+% points, in the kernel-split style of Helsing & Ojala.
+%
+% These corrections are MEANT TO BE ADDED to a smooth-Gauss-Legendre
+% panel evaluation of the kernel.  For a target far from the panel the
+% corrections vanish; for a target close to (or on) the panel they
+% recover the full singular contribution.
+%
+% Inputs:
+%   a, b   - complex endpoints of the panel (panel parameterized as a
+%            complexified contour from a to b).
+%   ztg    - nt x 1 complex target points.
+%   zsc    - 1 x Ng complex source nodes (Gauss-Legendre on the panel).
+%   nz     - 1 x Ng complex unit normals at source nodes.
+%   wzp    - 1 x Ng complex contour weights z'(t) * w_GL.
+%   awzp   - 1 x Ng real arclength weights |z'(t)| * w_GL.
+%   U      - Ng x Ng inverse Vandermonde from wlchs_src_precomp.
+%   ifself - 1 if the targets coincide with the source panel nodes
+%            (self-interaction), 0 otherwise.
+%
+% Outputs (each of size nt x Ng, target by source):
+%   wcmpL  - log-singular correction (always computed)
+%   wcmpC  - Cauchy singular correction (computed if nargout >= 2)
+%   wcmpH  - hypersingular correction  (computed if nargout >= 3)
+%   wcmpS  - supersingular correction  (computed if nargout >= 4)
+%
+% O(p^2) per target.  Vectorized over targets.
+%
+% Ported from testhelmos.m / Bruno-Lintner-Helsing close-evaluation
+% machinery.  See:
+%   Helsing & Ojala, Corner singularities for elliptic problems...
+%   J. Comput. Phys. 227 (2008) 8820-8840.
+
+zsc  = zsc(:).';
+nz   = nz(:).';
+wzp  = wzp(:).';
+awzp = awzp(:).';
+ztg  = ztg(:);
+
+Ng = numel(zsc);
+nt = numel(ztg);
+cc = (b-a)/2;
+zt = (ztg - (b+a)/2)/cc;
+
+% f(:,k+1) = \int_{-1}^{1} P_k(z)/(z - zt) dz, recurrence in zt
+f = zeros(nt, Ng+1);
+if ifself == 1
+    upp = log(1 - zt);
+    loo = log(-1 - zt);
+    f(:,1) = upp - loo;
+    ind = imag(f(:,1)) < -1.1;  f(ind,1) = f(ind,1) + 1i*pi;
+    ind = imag(f(:,1)) >  1.1;  f(ind,1) = f(ind,1) - 1i*pi;
+else
+    % decide per target which side of the (complexified) panel it is on
+    ifleft = false(nt,1);
+    zdiff  = ztg - zsc;            % nt x Ng
+    xd = real(zdiff); yd = imag(zdiff);
+    d2 = xd.*xd + yd.*yd;
+    [~, nearidx] = min(d2, [], 2);
+
+    zsctr   = (zsc - (b+a)/2)/cc;
+    imzsctr = imag(zsctr);
+    [~, mxi] = max(abs(imzsctr));
+    isconvex = sign(imzsctr(mxi)) == -1;
+
+    nz_re = real(nz); nz_im = imag(nz);
+    for k = 1:nt
+        rezt = real(zt(k));
+        imzt = imag(zt(k));
+        nk = nearidx(k);
+        costheta = xd(k,nk)*nz_re(nk) + yd(k,nk)*nz_im(nk);
+        if costheta < 0
+            ifleft(k) = true;
+        end
+        if abs(rezt) < 1
+            if isconvex
+                if costheta < 0 && imzt < 0 && imzt > 1.1*min(imzsctr)
+                    if imzt < chnk.kernsplit.mydepth(zsctr,rezt,Ng)
+                        ifleft(k) = false;
+                    end
+                end
+            else
+                if costheta > 0 && imzt > 0 && imzt < 1.1*max(imzsctr)
+                    if imzt > chnk.kernsplit.mydepth(zsctr,rezt,Ng)
+                        ifleft(k) = true;
+                    end
+                end
+            end
+        end
+    end
+
+    gam    = -1i*ones(nt,1);
+    loggam = -0.5i*pi*ones(nt,1);
+    gam(ifleft)    = 1i;
+    loggam(ifleft) =  0.5i*pi;
+    f(:,1) = loggam + log((1-zt)./(gam.*(-1-zt)));
+end
+
+f(:,2) = 2 + zt.*f(:,1);
+for k = 1:Ng-1
+    f(:,k+2) = ((2*k+1)*zt.*f(:,k+1) - k*f(:,k))/(k+1);
+end
+
+% q(:,k+1) = \int_{-1}^{1} P_k(z)*log(z - zt) dz
+q = zeros(nt, Ng);
+P111   = log(abs((1-zt).*(1+zt)));
+q(:,1) = P111 - zt.*f(:,1) - 2;
+q(:,2:Ng) = (f(:,1:Ng-1) - f(:,3:Ng+1))./(3:2:2*Ng-1);
+
+% (nearly) log corrections
+tlog = log(abs((zsc - ztg)/cc));   % nt x Ng
+tlog(isinf(tlog)) = 0;
+wcmpL = imag((q*U)*cc.*conj(nz))./awzp - tlog;
+
+if nargout >= 2
+    tcau = wzp./(zsc - ztg)/1i;
+    tcau(isinf(tcau)) = 0;
+    wcmpC = (f(:,1:Ng)*U)/1i - tcau;
+end
+
+if nargout >= 3
+    fp = zeros(nt, Ng);
+    fp(:,2) = f(:,1);
+    for k = 1:Ng-2
+        fp(:,k+2) = (2*k+1)*f(:,k+1) + fp(:,k);
+    end
+    c2 = -(1./(1-zt) + (-1).^(0:Ng-1)./(1+zt));
+    fp = fp + c2;
+    thyp = wzp./(zsc - ztg).^2/1i;
+    thyp(isinf(thyp)) = 0;
+    wcmpH = (fp*U)/(1i*cc) - thyp;
+end
+
+if nargout >= 4
+    fpp = zeros(nt, Ng);
+    for k = 1:Ng-2
+        fpp(:,k+2) = (2*k+1)*fp(:,k+1) + fpp(:,k);
+    end
+    c3 = -0.5*(1./(1-zt).^2 + (-1).^(1:Ng)./(1+zt).^2) ...
+         -0.25*(0:Ng-1).*(1:Ng).*(1./(1-zt) + (-1).^(1:Ng)./(1+zt));
+    fpp = 0.5*fpp + c3;
+    tsup = wzp./(zsc - ztg).^3/1i;
+    tsup(isinf(tsup)) = 0;
+    wcmpS = (fpp*U)/(1i*cc^2) - tsup;
+end
+end

--- a/chunkie/+lege/exps.m
+++ b/chunkie/+lege/exps.m
@@ -23,6 +23,20 @@ if nargin > 1
     end
 end
 
+% Cache outputs keyed by (k,stab,nargout); kernel-split / RCIP loops
+% hit this thousands of times per build.
+persistent cache
+if isempty(cache); cache = struct(); end
+key = sprintf('k%d_s%d_n%d', k, stab, nargout);
+if isfield(cache, key)
+    e = cache.(key);
+    x = e.x;
+    if nargout > 1; w = e.w; end
+    if nargout > 2; u = e.u; end
+    if nargout > 3; v = e.v; end
+    return
+end
+
 if (or(stab,k<=200))
     if nargout > 1
         [x,w] = lege.rts_stab(k);
@@ -42,3 +56,9 @@ if nargout > 2
     d = (2.0*(1:k) - 1)/2.0;
     u = ((v).*(w(:)*d)).';
 end
+
+e = struct('x', x);
+if nargout > 1; e.w = w; end
+if nargout > 2; e.u = u; end
+if nargout > 3; e.v = v; end
+cache.(key) = e;

--- a/chunkie/chunkerkerneval.m
+++ b/chunkie/chunkerkerneval.m
@@ -48,9 +48,14 @@ function [fints,ids] = chunkerkerneval(chnkobj,kern,dens,targobj,opts)
 %           false, a hybrid algorithm is used, where the smooth rule is 
 %           applied for targets separated by opts.fac*length of chunk from
 %           a given chunk and adaptive integration is used otherwise
-%       opts.fac = the factor times the chunk length used to decide 
+%       opts.fac = the factor times the chunk length used to decide
 %               between adaptive/smooth rule
 %       opts.eps = tolerance for adaptive integration
+%       opts.forcewlchs - if = true, use kernel-split (Helsing-style)
+%               panel quadrature for close evaluation. Supports Laplace
+%               (s/d/sp) scalar kernels -- kern must be a single kernel
+%               object. Delivers 10+ digits of accuracy at close
+%               off-curve targets. (false)
 %
 % output:
 %   fints - opdims(1) x nt array of integral values where opdims is the 
@@ -137,6 +142,87 @@ if isfield(opts,'accel'); opts_use.accel = opts.accel; end
 if isfield(opts,'fac'); opts_use.fac = opts.fac; end
 if isfield(opts,'eps'); opts_use.eps = opts.eps; end
 if isfield(opts,'proxybylevel'); opts_use.proxybylevel = opts.proxybylevel; end
+
+% Kernel-split (Helsing-style) panel quadrature for accurate close
+% evaluation of Laplace S, D, S' layer potentials.
+fw_raw = [];
+if isfield(opts,'forcewlchs') && ~isempty(opts.forcewlchs)
+    fw_raw = opts.forcewlchs;
+end
+if (islogical(fw_raw) || isnumeric(fw_raw)) && isscalar(fw_raw)
+    use_wlchs = logical(fw_raw);
+else
+    use_wlchs = false;
+end
+
+if use_wlchs
+    % Single scalar kernel (laplace, opdims=[1 1]).
+    if size(kern,1) ~= 1 || size(kern,2) ~= 1 || ~isa(kern,'kernel')
+        error("CHUNKERKERNEVAL: forcewlchs=true requires a single kernel object");
+    end
+    is_lap = strcmpi(kern.name, 'laplace');
+    if ~is_lap
+        error("CHUNKERKERNEVAL: forcewlchs supports Laplace kernels");
+    end
+    if ~ismember(lower(kern.type), {'s','single','d','double','sp','sprime'})
+        error("CHUNKERKERNEVAL: forcewlchs currently supports only s/d/sp layers");
+    end
+    wlchs_type   = kern.type;
+    wlchs_family = kern.name;
+
+    src_probe = struct('r',[0;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
+    tgt_probe = struct('r',[1;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
+    if strcmpi(wlchs_type,'s') || strcmpi(wlchs_type,'single')
+        tgt_probe.r = [2;0];
+        val_probe = kern.eval(src_probe, tgt_probe);
+        base_probe = -log(2)/(2*pi);
+    else
+        val_probe = kern.eval(src_probe, tgt_probe);
+        base_probe = 1/(2*pi);
+    end
+    wlchs_coef = val_probe / base_probe;
+
+    % Non-rcipsav path: dispatch directly to kernsplit on the (possibly
+    % merged) chunker. Targets pass through as raw point coords or struct
+    % with .r and .n when normals are needed (sp).
+    if length(chnkr) > 1
+        chnkr_use = merge(chnkr);
+    else
+        chnkr_use = chnkr;
+    end
+    targ_pts = local_target_points(targobj);
+    needs_tgt_normals = any(strcmpi(wlchs_type, {'sp','sprime'}));
+    targ_n = [];
+    if needs_tgt_normals
+        targ_n = local_target_normals(targobj);
+        if isempty(targ_n)
+            error(['CHUNKERKERNEVAL: forcewlchs with sp kernel ' ...
+                   'requires target normals; pass targobj as a struct with .n']);
+        end
+    end
+    hpe_opts = struct();
+    if isfield(opts,'forcefmm') && opts.forcefmm
+        hpe_opts.forcefmm = true;
+    end
+    if needs_tgt_normals
+        targ_for_eval = struct('r', targ_pts, 'n', targ_n);
+    else
+        targ_for_eval = targ_pts;
+    end
+    switch lower(wlchs_family)
+        case 'laplace'
+            fints = wlchs_coef * chnk.kernsplit.lap2d_panel_eval(chnkr_use, ...
+                wlchs_type, dens, targ_for_eval, [], hpe_opts);
+        otherwise
+            error('CHUNKERKERNEVAL: forcewlchs family %s not supported', wlchs_family);
+    end
+    if icgrph && size(kern,1) > 1
+        ids = chunkgraphinregion(chnkobj, targ_pts);
+    else
+        ids = ones(size(targ_pts,2),1);
+    end
+    return
+end
 
 % Assign appropriate object to targinfo
 targinfo = [];
@@ -504,10 +590,39 @@ else % do only those flagged
         indji = (ji-1)*opdims(1);
         ind = (indji(:)).' + (1:opdims(1)).';
         ind = ind(:);
-        fints(ind) = fints(ind) + fints1;        
+        fints(ind) = fints(ind) + fints1;
 
     end
-    
+
 end
 
+end
+
+
+function r = local_target_points(targobj)
+%LOCAL_TARGET_POINTS  pull the dim x nt point array from any of the
+% supported targobj forms (chunker, chunkgraph, struct with .r, raw array).
+if isa(targobj,'chunker') || isa(targobj,'chunkgraph')
+    r = targobj.r(:,:);
+elseif isstruct(targobj) && isfield(targobj,'r')
+    r = targobj.r(:,:);
+elseif isnumeric(targobj)
+    r = targobj;
+else
+    error('CHUNKERKERNEVAL: unsupported targobj type');
+end
+end
+
+
+function n = local_target_normals(targobj)
+%LOCAL_TARGET_NORMALS  pull a dim x nt target-normal array if the target
+% representation carries one; return [] otherwise. Used for forcewlchs
+% with normal-derivative kernels (sp).
+if isa(targobj,'chunker') || isa(targobj,'chunkgraph')
+    n = targobj.n(:,:);
+elseif isstruct(targobj) && isfield(targobj,'n') && ~isempty(targobj.n)
+    n = targobj.n(:,:);
+else
+    n = [];
+end
 end

--- a/chunkie/chunkermat.m
+++ b/chunkie/chunkermat.m
@@ -77,7 +77,21 @@ function [sysmat,varargout] = chunkermat(chnkobj,kern,opts,ilist)
 %                    adaptive quadrature for near touching panels on
 %                    different chunkers within rcip
 %           opts.eps = (1e-14) tolerance for adaptive quadrature
-%  ilist - cell array of integer arrays ([]), list of panel interactions that 
+%           opts.forcewlchs = kernel-split self/adjacent-panel correction
+%                    for Laplace S, D, S', D' kernels. After GGQ buildmat
+%                    fills self+adj with generic singular quadrature,
+%                    overwrite supported entries with wLCHS values from
+%                    chnk.kernsplit. Two forms supported:
+%                       opts.forcewlchs = true
+%                            (kern must be a single lap2d scalar kernel
+%                            of type 's', 'd', 'sp', or 'dp'; scalar
+%                            multiplier auto-extracted by probing).
+%                       opts.forcewlchs = struct('layout', L)
+%                            where L is an opdims(1)-by-opdims(2) cell
+%                            array; L{r,c} = [] for a zero block, or
+%                            {type, coef} / struct('type',t,'coef',a)
+%                            for a Laplace scalar kernel.
+%  ilist - cell array of integer arrays ([]), list of panel interactions that
 %          should be ignored when constructing matrix entries or quadrature
 %          corrections. 
 %
@@ -197,6 +211,13 @@ if (isfield(opts,'adaptive_correction'))
 end
 if (isfield(opts,'rcip_adaptive_correction'))
     rcip_adaptive_correction = opts.rcip_adaptive_correction;
+end
+
+% forcewlchs: kernel-split self/adjacent-panel correction for Laplace
+% S/D/Sp/Dp kernels. See doc above for accepted forms.
+forcewlchs_opt = [];
+if isfield(opts,'forcewlchs') && ~isempty(opts.forcewlchs)
+    forcewlchs_opt = opts.forcewlchs;
 end
 
 nchunkers = length(chnkrs);
@@ -433,13 +454,42 @@ for i=1:nchunkers
     elseif strcmpi(quad,'native')
 
         if nonsmoothonly
-            sysmat_tmp = sparse(chnkr.npt,chnkr.npt);
+            sysmat_tmp = sparse(opdims(1)*chnkr.npt, opdims(2)*chnkr.npt);
         else
             sysmat_tmp = chnk.quadnative.buildmat(chnkr,ftmp,opdims);
         end
     else
         warning('specified quadrature method not available');
         return;
+    end
+
+    if ~isempty(forcewlchs_opt)
+        % In ~nonsmoothonly mode, sysmat_tmp has smooth GL values for the
+        % whole block (native quad) or smooth + GGQ self/adj corrections
+        % (ggq quad). chunkermat_apply_wlchs_adj ADDs the kernel-split
+        % delta over smooth GL on self+adj entries. When ggq quad is in
+        % use, the GGQ self/adj corrections it wrote get overwritten by
+        % the wLCHS values -- so prefer quad='native' for cleanliness.
+        % In nonsmoothonly mode, sysmat_tmp is sparse (zero from native,
+        % or GGQ corrections from ggq); add wLCHS deltas as sparse too.
+        if size(kern,1) > 1 || size(kern,2) > 1
+            block_kern = kern(i,i);
+        else
+            block_kern = kern;
+        end
+        try
+            sysmat_tmp = chunkermat_apply_wlchs_adj( ...
+                sysmat_tmp, chnkr, opdims, block_kern, forcewlchs_opt, nonsmoothonly);
+        catch ME
+            if contains(ME.message, 'forcewlchs') ...
+                    || contains(ME.message, 'wlchs') ...
+                    || contains(ME.message, 'unsupported')
+                warning('chunkermat:wlchsSkipped', ...
+                    'forcewlchs skipped on chunker %d: %s', i, ME.message);
+            else
+                rethrow(ME);
+            end
+        end
     end
 
     if adaptive_correction
@@ -734,4 +784,231 @@ end
 
 mat = sparse(is,js,vs,opdims(1)*nt,opdims(2)*chnkr.npt);
 
+end
+
+
+function sysmat = chunkermat_apply_wlchs_adj(sysmat, chnkr, opdims, kern, fw, nonsmoothonly)
+% Apply wLCHS self/adjacent-panel corrections to sysmat for Laplace
+% S/D/Sp/Dp entries. See chunkermat opts.forcewlchs comment.
+%
+% Behaviour depends on nonsmoothonly:
+%   false (default) - sysmat is dense; ENTRIES on self+adj blocks are
+%                     OVERWRITTEN with smooth-GL + wLCHS-delta. Used by
+%                     the dense matrix-build path.
+%   true            - sysmat is sparse; wLCHS deltas (smooth-subtracted)
+%                     are ADDED on top of whatever GGQ corrections were
+%                     already in sysmat. For matrix-free apply, the caller
+%                     should also use quad='native' so sysmat starts at
+%                     zero and the result is just the wLCHS delta.
+if nargin < 6 || isempty(nonsmoothonly), nonsmoothonly = false; end
+
+% Decode forcewlchs spec: build a 2D cell `layout` (opdims(1) x opdims(2))
+% where layout{r,c} is either [] (no wLCHS, leave entry alone), or
+% struct('type', t, 'coef', a, 'family', 'laplace').
+m = opdims(1); n = opdims(2);
+layout = cell(m, n);
+lap_types  = {'s','single','d','double','sp','sprime','dp','dprime'};
+if islogical(fw) || (isnumeric(fw) && isscalar(fw))
+    % Boolean form: kern must be a single scalar Laplace kernel, or zero.
+    if ~fw, return; end
+    if isa(kern, 'kernel') && (strcmpi(kern.name, 'zeros') || ...
+            (isprop(kern, 'iszero') && kern.iszero))
+        return;
+    end
+    fam = wlchs_kernel_family(kern);
+    if isempty(fam)
+        error("chunkermat: opts.forcewlchs=true requires a single lap2d kernel");
+    end
+    t = lower(kern.type);
+    if m ~= 1 || n ~= 1
+        error("chunkermat: opts.forcewlchs=true requires a single scalar (opdims=[1 1]) lap kernel");
+    end
+    if ~ismember(t, lap_types)
+        error("chunkermat: opts.forcewlchs=true: lap kernel type %s not supported", kern.type);
+    end
+    coef = wlchs_extract_scalar(kern, t, fam);
+    layout{1,1} = struct('type', t, 'coef', coef, 'family', fam);
+elseif isstruct(fw)
+    if ~isfield(fw, 'layout')
+        error("chunkermat: opts.forcewlchs struct needs field 'layout'");
+    end
+    fam_default = 'laplace';
+    if isfield(fw, 'family') && ~isempty(fw.family)
+        fam_default = lower(fw.family);
+    end
+    if ~strcmp(fam_default, 'laplace')
+        error("chunkermat: opts.forcewlchs.family must be 'laplace'");
+    end
+    L = fw.layout;
+    if ~iscell(L) || size(L,1) ~= m || size(L,2) ~= n
+        error("chunkermat: opts.forcewlchs.layout must be %dx%d cell", m, n);
+    end
+    for r = 1:m
+        for c = 1:n
+            entry = L{r,c};
+            if isempty(entry); continue; end
+            if iscell(entry)
+                t = entry{1}; a = entry{2};
+            elseif isstruct(entry)
+                t = entry.type;
+                a = entry.coef;
+            else
+                error("chunkermat: opts.forcewlchs.layout{%d,%d} bad form", r, c);
+            end
+            if strcmpi(t, 'zero'); continue; end
+            if ~ismember(lower(t), lap_types)
+                error("chunkermat: forcewlchs (laplace): layout entry type %s not supported", t);
+            end
+            layout{r,c} = struct('type', lower(t), 'coef', a, 'family', 'laplace');
+        end
+    end
+else
+    error("chunkermat: opts.forcewlchs has unsupported type");
+end
+
+% For each non-empty (r,c) in layout, OVERWRITE self and adjacent block
+% entries with smooth-GL + wLCHS-delta (replacing the inadequate generic
+% GGQ values that the buildmat already wrote).
+ngl = chnkr.k;
+% U_src (per-panel inverse Vandermonde for wlchs) is kernel-INDEPENDENT,
+% so build it once across the layout iteration. Cells fill lazily as
+% lap2d_*_correction touch them.
+U_src_cell = cell(1, chnkr.nch);
+for r = 1:m
+    for c = 1:n
+        spec = layout{r,c};
+        if isempty(spec); continue; end
+
+        % --- Self-panel correction ---
+        if wlchs_has_self_correction(spec.type, spec.family)
+            [delta_self_a, U_src_cell] = wlchs_self_correction_dispatch( ...
+                spec, chnkr, spec.type, U_src_cell);
+            self_coef_a = spec.coef;
+            for ich = 1:chnkr.nch
+                ji = (1:ngl).' + (ich-1)*ngl;
+                rows_blk = (ji - 1) * m + r;
+                cols_blk = (ji.' - 1) * n + c;
+                d_blk = self_coef_a * full(delta_self_a(ji, ji));
+                if nonsmoothonly
+                    sysmat(rows_blk, cols_blk) = d_blk;
+                else
+                    Kb = wlchs_kernel_eval(spec, spec.type, ...
+                        chnkr.r(:,:,ich), chnkr.n(:,:,ich), ...
+                        chnkr.r(:,:,ich), chnkr.n(:,:,ich));
+                    awzp = chnkr.wts(:, ich).';
+                    M_smooth = spec.coef * (Kb .* awzp);
+                    M_smooth(1:ngl+1:end) = 0;
+                    sysmat(rows_blk, cols_blk) = M_smooth + d_blk;
+                end
+            end
+        end
+
+        % --- Adjacent-panel correction ---
+        [delta_a, U_src_cell] = wlchs_adj_correction_dispatch( ...
+            spec, chnkr, spec.type, U_src_cell);
+        adj_coef_a = spec.coef;
+        for ich = 1:chnkr.nch
+            for io = 1:2
+                jch = chnkr.adj(io, ich);
+                if jch <= 0; continue; end
+                ji    = (1:ngl).' + (ich-1)*ngl;
+                jcols = (jch-1)*ngl + (1:ngl);
+                rows_blk = (ji - 1) * m + r;
+                cols_blk = (jcols - 1) * n + c;
+                d_blk = adj_coef_a * full(delta_a(ji, jcols));
+                if nonsmoothonly
+                    sysmat(rows_blk, cols_blk) = d_blk;
+                else
+                    Kb = wlchs_kernel_eval(spec, spec.type, ...
+                        chnkr.r(:,:,jch), chnkr.n(:,:,jch), ...
+                        chnkr.r(:,:,ich), chnkr.n(:,:,ich));
+                    awzp = chnkr.wts(:, jch).';
+                    M_smooth = spec.coef * (Kb .* awzp);
+                    sysmat(rows_blk, cols_blk) = M_smooth + d_blk;
+                end
+            end
+        end
+    end
+end
+end
+
+function fam = wlchs_kernel_family(kern)
+% Returns 'laplace' or '' if the kernel is unsupported by the wLCHS path.
+fam = '';
+if ~isa(kern, 'kernel'), return; end
+if strcmpi(kern.name, 'zeros'), return; end
+if strcmpi(kern.name, 'laplace'), fam = 'laplace'; return; end
+end
+
+function tf = wlchs_has_self_correction(type, family)
+% Laplace: S, D, S', D' all have nontrivial self corrections.
+if nargin < 2 || isempty(family), family = 'laplace'; end
+switch lower(family)
+    case 'laplace'
+        tf = ismember(lower(type), {'s','single','d','double','sp','sprime','dp','dprime'});
+    otherwise
+        tf = false;
+end
+end
+
+function [delta, U_src_cell] = wlchs_self_correction_dispatch(spec, chnkr, type, U_src_cell)
+switch lower(spec.family)
+    case 'laplace'
+        [delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction(chnkr, type, U_src_cell);
+    otherwise
+        error('wlchs_self_correction_dispatch: unsupported family %s', spec.family);
+end
+end
+
+function [delta, U_src_cell] = wlchs_adj_correction_dispatch(spec, chnkr, type, U_src_cell)
+switch lower(spec.family)
+    case 'laplace'
+        [delta, U_src_cell] = chnk.kernsplit.lap2d_adj_correction(chnkr, type, U_src_cell);
+    otherwise
+        error('wlchs_adj_correction_dispatch: unsupported family %s', spec.family);
+end
+end
+
+function K = wlchs_kernel_eval(spec, type, src_r, src_n, tgt_r, tgt_n, varargin)
+% Evaluate the bare kernel of given family/type at (src, tgt) GL nodes.
+si.r = src_r; si.n = src_n;
+ti.r = tgt_r; ti.n = tgt_n;
+switch lower(spec.family)
+    case 'laplace'
+        switch lower(type)
+            case {'s','single'},  K = chnk.lap2d.kern(si, ti, 's');
+            case {'d','double'},  K = chnk.lap2d.kern(si, ti, 'd');
+            case {'sp','sprime'}, K = chnk.lap2d.kern(si, ti, 'sprime');
+            case {'dp','dprime'}, K = chnk.lap2d.kern(si, ti, 'dprime');
+            otherwise
+                error('wlchs_kernel_eval: lap type %s not supported', type);
+        end
+    otherwise
+        error('wlchs_kernel_eval: unsupported family %s', spec.family);
+end
+end
+
+function coef = wlchs_extract_scalar(kern, t, family)
+% Probe the kern eval at a known src/tgt pair, divide by analytic value.
+% Result is the scalar prefactor on top of the bare kernel (=1 for plain
+% kernel('lap',type); !=1 for scalar-multiplied kernels). For Laplace S
+% the bare value at r=1 is 0 (log 1 = 0), so we probe at r=2 instead.
+if nargin < 3 || isempty(family), family = 'laplace'; end
+src_probe = struct('r',[0;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
+tgt_probe = struct('r',[2;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
+val = kern.eval(src_probe, tgt_probe);
+switch lower(family)
+    case 'laplace'
+        switch lower(t)
+            case {'s','single'},  base = chnk.lap2d.kern(src_probe, tgt_probe, 's');
+            case {'d','double'},  base = chnk.lap2d.kern(src_probe, tgt_probe, 'd');
+            case {'sp','sprime'}, base = chnk.lap2d.kern(src_probe, tgt_probe, 'sprime');
+            case {'dp','dprime'}, base = chnk.lap2d.kern(src_probe, tgt_probe, 'dprime');
+            otherwise
+                error('wlchs_extract_scalar: lap type %s not supported', t);
+        end
+        coef = val / base;
+    otherwise
+        error('wlchs_extract_scalar: unsupported family %s', family);
+end
 end

--- a/devtools/test/chunkermat_lap_forcewlchsTest.m
+++ b/devtools/test/chunkermat_lap_forcewlchsTest.m
@@ -1,0 +1,69 @@
+function chunkermat_lap_forcewlchsTest()
+%CHUNKERMAT_LAP_FORCEWLCHSTEST  Verify chunkermat opts.forcewlchs dispatches
+%   correctly to chnk.kernsplit Laplace self/adj corrections (s, d, sp, dp).
+%
+%   The test checks operator action against analytic identities on a unit
+%   circle.  We don't compare matrix entries against chunkermat default
+%   because the two quadrature schemes (chunkermat default's smooth-GL +
+%   splitinfo vs forcewlchs's smooth-GL + Helsing log moments) encode the
+%   same operator differently and need not agree entry-wise.
+
+cparams = []; cparams.ta = 0; cparams.tb = 2*pi; cparams.ifclosed = true;
+cparams.maxchunklen = 2*pi/8;
+pref = []; pref.k = 16;
+chnkr = chunkerfunc(@(t) circle_param(t), cparams, pref);
+N = chnkr.npt;
+sig1 = ones(N, 1);
+
+% --- 's' single-layer ---
+% On unit circle, S[1] = -1/(2*pi) * integral log(|x-y|) dy = 0.
+S_wl = chunkermat(chnkr, kernel('lap','s'), ...
+                  struct('quad','native','forcewlchs',true));
+val_S = S_wl * sig1;
+err_S = norm(val_S, 'inf');
+fprintf('  lap s  : ||S*1||_inf  = %.3e (expect 0 on unit circle)\n', err_S);
+assert(err_S < 1e-12);
+
+% --- 'd' double-layer: D[1] = -1/2 (interior limit on closed smooth curve) ---
+D_wl = chunkermat(chnkr, kernel('lap','d'), ...
+                  struct('quad','native','forcewlchs',true));
+val_D = D_wl * sig1;
+err_D = norm(val_D - (-0.5), 'inf');
+fprintf('  lap d  : ||D*1 - (-1/2)||_inf = %.3e\n', err_D);
+assert(err_D < 1e-12);
+
+% --- 'sp' normal derivative of single layer: K*[1] = -1/2 in chunkie convention.
+%     SLP(1)|interior = 0 (harmonic, zero on boundary).  Interior normal-deriv
+%     trace = +1/2 + K*[1] = 0 (Colton-Kress jump rel.) => K*[1] = -1/2.
+SP_wl = chunkermat(chnkr, kernel('lap','sp'), ...
+                   struct('quad','native','forcewlchs',true));
+val_SP = SP_wl * sig1;
+err_SP = norm(val_SP - (-0.5), 'inf');
+fprintf('  lap sp : ||S''*1 - (-1/2)||_inf = %.3e\n', err_SP);
+assert(err_SP < 1e-11);
+
+% --- 'dp' hypersingular: D'[1] = 0 (since D maps constants to constants) ---
+DP_wl = chunkermat(chnkr, kernel('lap','dp'), ...
+                   struct('quad','native','forcewlchs',true));
+val_DP = DP_wl * sig1;
+err_DP = norm(val_DP, 'inf');
+fprintf('  lap dp : ||D''*1||_inf = %.3e\n', err_DP);
+assert(err_DP < 1e-10);
+
+% --- Boolean form on a scalar-multiplied kernel: 3.7 * S[1] = 0 ---
+kern_scaled = 3.7 * kernel('lap','s');
+S_scaled = chunkermat(chnkr, kern_scaled, ...
+                      struct('quad','native','forcewlchs',true));
+err_scaled = norm(S_scaled * sig1, 'inf');
+fprintf('  3.7*s  : ||3.7*S*1||_inf = %.3e\n', err_scaled);
+assert(err_scaled < 1e-11);
+
+fprintf('PASS: chunkermat forcewlchs lap dispatch verified for s/d/sp/dp\n');
+end
+
+function [r, d, d2] = circle_param(t)
+ct = cos(t); st = sin(t);
+r  = [ct(:).';  st(:).'];
+d  = [-st(:).'; ct(:).'];
+d2 = [-ct(:).'; -st(:).'];
+end


### PR DESCRIPTION
## Summary
Adds `opts.forcewlchs` to `chunkermat` and `chunkerkerneval` for kernel-split (Helsing-style log-corrected) close-evaluation quadrature on Laplace scalar layer potentials. The framework is structured to extend to other kernel families (Helmholtz, Stokes, elasticity) in follow-up PRs.

## What's included
- **New `chnk.kernsplit` package**
  - `lap2d_self_correction`, `lap2d_adj_correction`, `lap2d_panel_eval`, `lap2d_close` — Laplace S, D, S', D' on-curve and close-eval routines.
  - Shared utilities: `wlchs_src_precomp`, `wlchs_target`, `wfrak_log`, `mydepth`.
- **`chunkermat`**: `opts.forcewlchs = true` (single lap2d scalar kernel) or `struct('layout', L)` (block kernels). After `ggq`/`native` build, self+adjacent entries are replaced with smooth-GL + Helsing log-moment corrections.
- **`chunkerkerneval`**: `opts.forcewlchs = true` for close-eval field evaluation (Laplace s/d/sp).
- **`chnk.lege.exps`**: persistent (k, stab, nargout) cache; kernsplit & RCIP loops call this thousands of times per matrix build.
- **Bug fix**: `chunkermat` with `quad='native' + nonsmoothonly` allocated `sparse(npt, npt)` instead of `sparse(opdims(1)*npt, opdims(2)*npt)`. Trivial for scalar kernels, correctness fix for block kernels.

## Test plan
- [x] `devtools/test/chunkermat_lap_forcewlchsTest.m` (new) — exercises s, d, sp, dp on the unit circle (`||S*1||`, `||D*1 + 1/2||`, `||S'*1 + 1/2||`, `||D'*1||` all < 1e-11) plus a scalar-multiplied kernel.
- [x] `devtools/test/chunkerkerneval_greenlapTest.m` (regression) — FLAM, direct, and FMM quadrature all agree at 1.5e-15.

## Notes
- Stacked: this is PR 1 of 6. Follow-ups add Helmholtz, Stokes, elasticity kernsplit; RCIP backward recursion for field eval; and Helmholtz open-arc support.
- Original implementation contributed by @sj90101.
