### PR TITLE
Extend kernel-split forcewlchs to Helmholtz S/D/Sp/Dp + combined kernels

### DIFF
--- a/chunkie/+chnk/+kernsplit/helm2d_adj_correction.m
+++ b/chunkie/+chnk/+kernsplit/helm2d_adj_correction.m
@@ -1,0 +1,182 @@
+function [delta, U_src_cell] = helm2d_adj_correction(chnkr, type, zk, U_src_cell)
+%CHNK.HELSINGO.HELM2D_ADJ_CORRECTION  adjacent-panel close-correction
+% delta for a 2D Helmholtz layer-potential system matrix.
+%
+% Returns a sparse matrix `delta` such that
+%   sysmat_close = sysmat_smooth + delta
+% where sysmat_smooth is a system matrix built by simple Gauss-Legendre
+% panel quadrature (no kernel-split), and sysmat_close is a properly
+% close-corrected version on adjacent panel pairs.  Self and far entries
+% of `delta` are zero; only adjacent pairs are populated.
+%
+% Method: testhelmos's kernel-split.  Log moments computed in the source
+% panel's canonical [-1,1] frame via wfrak_log.  Hypersingular moments
+% from wlchs_target with ifself=0 (testhelmos uses the same routine for
+% on-curve adjacent HypC, since branch-cut issues only affect the log
+% moment).  Combined via helm2d_close.
+%
+% **Supported kernel types** (kernel-specific coefficients in helm2d_close):
+%   - 's'  (single layer)
+%   - 'd'  (double layer)
+%   - 'sp' (S' = normal derivative of single layer, target side)
+%   - 'dp' (hypersingular T = D')
+% Other types must add a new case in helm2d_close before this routine
+% can handle them.  For unsupported types, errors out.
+%
+% **Limitations:**
+%   - Single chunker only (one connected sequence of panels).  Block
+%     kernels and multi-edge chunkgraphs handled by the caller.
+%   - The target row nearest the shared joint endpoint of two panels
+%     loses 3-4 digits relative to other rows (a known wLCHS limitation
+%     for targets canonically very close to the panel boundary).  The
+%     average operator action over a smooth density typically still
+%     achieves 12+ digits.
+%
+% Inputs:
+%   chnkr - chunker object.
+%   type  - 's', 'd', or 'dp'.
+%   zk    - wavenumber.
+%
+% Output:
+%   delta - sparse npt x npt matrix.  Add to a smooth-GL system matrix
+%           to overwrite (sysmat_smooth_adj + delta = wLCHS_close_eval_adj).
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+npt = chnkr.npt;
+
+[T_GL, wgl, U_GL_panel] = lege.exps(ngl);
+% closed form: P_n(-1) = (-1)^n, P_n(1) = 1
+P_left  = (-1).^(0:ngl-1);
+P_right = ones(1, ngl);
+
+if nargin < 4 || isempty(U_src_cell)
+    U_src_cell = cell(1, nch);
+end
+
+[rends, ~] = chunkends(chnkr);
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));     % nch x 1 (left ends)
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));     % nch x 1 (right ends)
+speed_left  = zeros(nch, 1);
+speed_right = zeros(nch, 1);
+for ip = 1:nch
+    di = chnkr.d(:, :, ip);            % 2 x ngl
+    cdi = U_GL_panel * (di.');         % ngl x 2 Legendre coefs
+    dleft  = P_left  * cdi;            % 1 x 2
+    dright = P_right * cdi;
+    speed_left(ip)  = norm(dleft);
+    speed_right(ip) = norm(dright);
+end
+
+ii = []; jj = []; vv = [];
+
+for ip_src = 1:nch
+    src_idx = (ip_src-1)*ngl + (1:ngl);
+    zsrc = (chnkr.r(1,:,ip_src) + 1i*chnkr.r(2,:,ip_src));
+    nz_s = (chnkr.n(1,:,ip_src) + 1i*chnkr.n(2,:,ip_src));
+    d_s  = (chnkr.d(1,:,ip_src) + 1i*chnkr.d(2,:,ip_src));
+    wzp  = d_s .* wgl(:).';
+    awzp = chnkr.wts(:, ip_src).';
+    a = endsa(ip_src);
+    b = endsb(ip_src);
+
+    % U_src for HypC (curve-specific Legendre Vandermonde inverse)
+    if isempty(U_src_cell{ip_src})
+        U_src_cell{ip_src} = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc);
+    end
+    U_src = U_src_cell{ip_src};
+
+    for side = [1, 2]   % side==1: target panel BEFORE source (superdiag)
+                        % side==2: target panel AFTER source (subdiag)
+        ip_tgt = chnkr.adj(side, ip_src);
+        if ip_tgt <= 0; continue; end
+
+        tgt_idx = (ip_tgt-1)*ngl + (1:ngl);
+        ztgt = (chnkr.r(1,:,ip_tgt) + 1i*chnkr.r(2,:,ip_tgt)).';
+        nzt  = (chnkr.n(1,:,ip_tgt) + 1i*chnkr.n(2,:,ip_tgt)).';
+
+        % alpha = canonical-parameter length ratio of target/source.
+        % Computed from speed-ratio at the joint endpoint where the panels
+        % meet (their physical d agrees there, so the ratio of canonical
+        % d's gives the canonical-length ratio).
+        if side == 1
+            % target panel BEFORE source: joint = source's LEFT endpoint
+            % = target's RIGHT endpoint
+            alpha = speed_right(ip_tgt) / speed_left(ip_src);
+            trans = -1 - alpha;
+        else
+            % target panel AFTER source: joint = source's RIGHT endpoint
+            % = target's LEFT endpoint
+            alpha = speed_left(ip_tgt) / speed_right(ip_src);
+            trans = 1 + alpha;
+        end
+        mscale = alpha;
+
+        [WfrakL, accept] = chnk.kernsplit.wfrak_log(ngl, trans, mscale);
+        if isempty(accept); continue; end
+
+        % LogC delta (canonical): WfrakL/W minus smooth-GL log value
+        T_acc = T_GL(accept);
+        if side == 1
+            Ta = T_GL + 1;
+            Tb = (1 - T_acc) * alpha;
+            log_smooth = log(abs(Ta.' + Tb));
+        else
+            Ta = T_GL - 1;
+            Tb = (T_acc + 1) * alpha;
+            log_smooth = log(abs(Ta.' - Tb));
+        end
+        LogC_w = WfrakL ./ wgl(:).' - log_smooth;
+        LogC_full = zeros(ngl, ngl);
+        LogC_full(accept, :) = LogC_w;
+
+        % HypC for 'dp' from wlchs_target (ifself=0). Returned regardless of
+        % type so we can pass to helm2d_close uniformly. For 's' it's unused.
+        if strcmpi(type, 'dp') || strcmpi(type, 't')
+            [~, ~, HypC_full] = chnk.kernsplit.wlchs_target( ...
+                a, b, ztgt, zsrc, nz_s, wzp, awzp, U_src, 0);
+            CauC_full = [];
+        elseif strcmpi(type, 'd') || strcmpi(type, 'double') ...
+                || strcmpi(type, 'sp') || strcmpi(type, 'sprime')
+            [~, CauC_full] = chnk.kernsplit.wlchs_target( ...
+                a, b, ztgt, zsrc, nz_s, wzp, awzp, U_src, 0);
+            HypC_full = [];
+        else
+            CauC_full = [];
+            HypC_full = [];
+        end
+
+        % delta block (M_close * awzp_or_density depending on type)
+        switch lower(type)
+            case {'s', 'single'}
+                Mc = chnk.kernsplit.helm2d_close('s', zk, ztgt, zsrc, nz_s, ...
+                                                wzp, LogC_full, []);
+                Mblk = Mc .* awzp;       % bake awzp -> M*density convention
+            case {'d', 'double'}
+                Mblk = chnk.kernsplit.helm2d_close('d', zk, ztgt, zsrc, nz_s, ...
+                                                  wzp, LogC_full, CauC_full);
+            case {'sp', 'sprime'}
+                % Helsing-Karlsson arXiv:1711.09796 §4.4 (eq. KAC):
+                % LogC + CauC. CauC vanishes on smooth Γ but is required
+                % near corners / branch points.
+                Mblk = chnk.kernsplit.helm2d_close('sp', zk, ztgt, zsrc, nz_s, ...
+                                                   wzp, LogC_full, CauC_full, [], ...
+                                                   nzt, awzp);
+            case {'dp', 'dprime', 't'}
+                Mblk = chnk.kernsplit.helm2d_close('dp', zk, ztgt, zsrc, nz_s, ...
+                                                   wzp, LogC_full, [], HypC_full, ...
+                                                   nzt, awzp);
+            otherwise
+                error('helm2d_adj_correction: unsupported type %s', type);
+        end
+
+        % accumulate sparse triples (Mblk IS the delta to add to smooth)
+        [I, J] = ndgrid(tgt_idx, src_idx);
+        ii = [ii; I(:)];
+        jj = [jj; J(:)];
+        vv = [vv; Mblk(:)];
+    end
+end
+
+delta = sparse(ii, jj, vv, npt, npt);
+end

--- a/chunkie/+chnk/+kernsplit/helm2d_close.m
+++ b/chunkie/+chnk/+kernsplit/helm2d_close.m
@@ -1,0 +1,113 @@
+function M = helm2d_close(type,zk,ztrg,zsrc,nz,wzp,LogC,CauC,HypC,nzt,awzp)
+%CHNK.HELSINGO.HELM2D_CLOSE  close-evaluation correction matrices for
+% Helmholtz layer potentials, in the kernel-split style of testhelmos.
+%
+% Supported types: 's' / 'single', 'd' / 'double', 'sp' / 'sprime',
+% 'dp' / 'dprime' / 't'.
+% These are the only types currently implemented; the LogC / CauC / HypC
+% moments are kernel-independent (from wlchs_target), but the closed-form
+% combination with the Helmholtz J_0 / J_1 / J_2 coefficients below is
+% specific to the (i/4) H_0(kr) Green's function used by chunkie.  Adding
+% another kernel requires a new case here.
+%
+% Output convention: M*density returns the close-evaluated layer
+% potential at the targets, EXCEPT for 's' where the caller multiplies
+% in awzp externally (i.e. M*(awzp.*density)).  This matches the existing
+% convention used by helm2d_panel_eval.
+%
+% Inputs:
+%   type  - 's'/'single', 'd'/'double', 'dp'/'dprime'/'t'.
+%   zk    - wavenumber.
+%   ztrg  - nt x 1 target points (complex form).
+%   zsrc  - 1 x Ng source points on panel (complex form).
+%   nz    - 1 x Ng complex unit normals at source nodes (used by 'd','dp').
+%   wzp   - 1 x Ng complex contour weights z'(t)*w_GL (used by 'd').
+%   LogC  - nt x Ng log-singular correction from wlchs_target (all types).
+%   CauC  - nt x Ng Cauchy correction from wlchs_target ('d' only).
+%   HypC  - nt x Ng hypersingular correction ('dp' only).
+%   nzt   - nt x 1 complex target normals ('dp' only).
+%   awzp  - 1 x Ng real arclength weights |z'(t)|*w_GL ('dp' only,
+%           baked into the LogC part of M to match the 'd' convention).
+%
+% Output:
+%   M     - nt x Ng correction matrix.
+
+% Note: chunkie's Helmholtz S = (i/4) H_0, so the log-singular part is
+% -(1/(2 pi)) log(zk r / 2) J_0(zk r) -- half of the testhelmos
+% convention -- and the close-correction matrices below carry the
+% corresponding factor of 1/(2 pi) instead of 1/pi.
+switch lower(type)
+    case {'s','single'}
+        M = -besselj(0, zk*abs(ztrg - zsrc))/(2*pi) .* LogC;
+
+    case {'d','double'}
+        zdiff = ztrg - zsrc;
+        tmp   = zk*abs(zdiff);
+        u = tmp.*besselj(1,tmp).*imag(wzp./zdiff);
+        M = -(u.*LogC + real(CauC))/(2*pi);
+
+    case {'sp','sprime'}
+        % S' = ∂_n_t G(t,s) = -(i/4) zk H_1(zk r) (n_t·(t-s))/r.
+        % Helsing-Karlsson, arXiv:1711.09796, Section 4.4 (eq. KAC), with
+        % chunkie's G = (i/4) H_0 introducing an extra factor 1/2 vs Helsing's
+        % (i/2) H_0:
+        %   G_L(r,r') = +(1/(2π)) (zk r) J_1(zk r) real(nzt/zdiff)
+        %   G_C(z,τ)  = nzt · conj(nz_s) / (2π)
+        %   G_H       = 0
+        % The Cauchy moment G_C is absorbed into G_0 on smooth Γ (Helsing
+        % demo12.m drops it), but is required near corners and branch points.
+        % The wcmpC delta from wlchs_target gives the per-pair (analytical -
+        % smooth GL) Cauchy correction.
+        % besselj(1,·) form keeps the formula valid for real OR complex zk
+        % (Helsing's imag(K) trick assumes real zk).
+        if nargin < 8 || isempty(CauC)
+            error('CHNK.HELSINGO.HELM2D_CLOSE: ''sp'' requires CauC');
+        end
+        if nargin < 10 || isempty(nzt)
+            error('CHNK.HELSINGO.HELM2D_CLOSE: ''sp'' requires target normals nzt');
+        end
+        if nargin < 11 || isempty(awzp)
+            error('CHNK.HELSINGO.HELM2D_CLOSE: ''sp'' requires source weights awzp');
+        end
+        nzt  = nzt(:);             % nt x 1
+        nz   = nz(:).';            % 1 x Ng
+        awzp = awzp(:).';          % 1 x Ng
+        zdiff = ztrg - zsrc;        % nt x Ng
+        tmp = zk*abs(zdiff);
+        cosNT = real(nzt ./ zdiff);
+        Mlog = (tmp .* besselj(1,tmp) .* cosNT) .* LogC .* awzp / (2*pi);
+        Mcau = real(nzt .* conj(nz) .* CauC) / (2*pi);
+        M = Mlog + Mcau;
+
+    case {'dp','dprime','t'}
+        % T = D' (hypersingular, normal-derivative of double-layer).
+        % Translated from testhelmos ToperC_near, divided by 2 (chunkie
+        % convention). awzp is baked into the LogC piece so that
+        % M*density is the close correction.
+        if nargin < 9 || isempty(HypC)
+            error('CHNK.HELSINGO.HELM2D_CLOSE: ''dp'' requires HypC');
+        end
+        if nargin < 10 || isempty(nzt)
+            error('CHNK.HELSINGO.HELM2D_CLOSE: ''dp'' requires target normals nzt');
+        end
+        if nargin < 11 || isempty(awzp)
+            error('CHNK.HELSINGO.HELM2D_CLOSE: ''dp'' requires source weights awzp');
+        end
+        nzt  = nzt(:);            % nt x 1
+        nz   = nz(:).';           % 1 x Ng
+        awzp = awzp(:).';         % 1 x Ng
+        zdiff = ztrg - zsrc;      % nt x Ng (broadcast)
+        tmp = zk*abs(zdiff);
+        % Coefficient of LogC: smooth function of (target,source).
+        Ta1 = (zk^2) * besselj(1,tmp)./tmp .* real(nzt .* conj(nz));
+        D1  = -real(nz   ./ zdiff);
+        D2  =  real(nzt  ./ zdiff);
+        Tb1 = tmp.^2 .* besselj(2,tmp) .* D1 .* D2;
+        Mlog = -(Ta1 + Tb1) .* LogC / (2*pi) .* awzp;
+        Mhyp = -real(nzt .* HypC) / (2*pi);
+        M = Mlog + Mhyp;
+
+    otherwise
+        error('CHNK.HELSINGO.HELM2D_CLOSE: unsupported type %s', type);
+end
+end

--- a/chunkie/+chnk/+kernsplit/helm2d_near_correction.m
+++ b/chunkie/+chnk/+kernsplit/helm2d_near_correction.m
@@ -1,0 +1,122 @@
+function delta = helm2d_near_correction(chnkr_src, chnkr_tgt, type, zk, dlim, coefs)
+%CHNK.HELSINGO.HELM2D_NEAR_CORRECTION  off-panel close-correction delta.
+%
+% Returns a sparse ntgt-by-nsrc correction matrix to add to smooth
+% Gauss-Legendre quadrature for target nodes on chnkr_tgt and source panels
+% on chnkr_src. This ports testhelmos's osbuildmat_nearcorrection path to
+% chunkie's G = (i/4)H_0 convention.
+%
+% Supported types: 's' / 'single', 'd' / 'double', 'sp' / 'sprime',
+% 'dp' / 'dprime' / 't', 'c' / 'combined' (coefs(1)*D + coefs(2)*S),
+% 'sc' / 'spcombined' (coefs(1)*S' + coefs(2)*S).
+
+if nargin < 5 || isempty(dlim)
+    dlim = 0.5;
+end
+if nargin < 6
+    coefs = [];
+end
+if (strcmpi(type,'c') || strcmpi(type,'combined')) && (isempty(coefs) || numel(coefs) ~= 2)
+    error("helm2d_near_correction: type 'c' requires coefs = [c1, c2]");
+end
+if (strcmpi(type,'sc') || strcmpi(type,'spcombined')) && (isempty(coefs) || numel(coefs) ~= 2)
+    error("helm2d_near_correction: type 'sc' requires coefs = [c_sp, c_s]");
+end
+
+ngl = chnkr_src.k;
+nch_src = chnkr_src.nch;
+nsrc = chnkr_src.npt;
+ntgt = chnkr_tgt.npt;
+
+[~, wgl] = lege.exps(ngl);
+
+ztgt_all = chnkr_tgt.r(1,:) + 1i*chnkr_tgt.r(2,:);
+nzt_all = chnkr_tgt.n(1,:) + 1i*chnkr_tgt.n(2,:);
+
+[rends, ~] = chunkends(chnkr_src);
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));
+
+ii = [];
+jj = [];
+vv = [];
+
+for ip = 1:nch_src
+    src_idx = (ip-1)*ngl + (1:ngl);
+    zsrc = chnkr_src.r(1,:,ip) + 1i*chnkr_src.r(2,:,ip);
+    nz = chnkr_src.n(1,:,ip) + 1i*chnkr_src.n(2,:,ip);
+    dz = chnkr_src.d(1,:,ip) + 1i*chnkr_src.d(2,:,ip);
+    wzp = dz .* wgl(:).';
+    awzp = chnkr_src.wts(:,ip).';
+
+    panlen = sum(awzp);
+    zdiff = ztgt_all(:) - zsrc;
+    d2 = real(zdiff).^2 + imag(zdiff).^2;
+    near = min(d2, [], 2) < (dlim*panlen)^2;
+    if ~any(near)
+        continue
+    end
+
+    tgt_idx = find(near).';
+    ztgt = ztgt_all(tgt_idx).';
+    U = chnk.kernsplit.wlchs_src_precomp(endsa(ip), endsb(ip), zsrc);
+
+    switch lower(type)
+        case {'s','single'}
+            LogC = chnk.kernsplit.wlchs_target( ...
+                endsa(ip), endsb(ip), ztgt, zsrc, nz, wzp, awzp, U, 0);
+            Mc = chnk.kernsplit.helm2d_close('s', zk, ztgt, zsrc, nz, wzp, LogC, []);
+            Mblk = Mc .* awzp;
+
+        case {'d','double'}
+            [LogC, CauC] = chnk.kernsplit.wlchs_target( ...
+                endsa(ip), endsb(ip), ztgt, zsrc, nz, wzp, awzp, U, 0);
+            Mblk = chnk.kernsplit.helm2d_close('d', zk, ztgt, zsrc, nz, wzp, LogC, CauC);
+
+        case {'sp','sprime'}
+            % S' near correction: LogC + CauC (Helsing-Karlsson 2018 §4.4).
+            [LogC, CauC] = chnk.kernsplit.wlchs_target( ...
+                endsa(ip), endsb(ip), ztgt, zsrc, nz, wzp, awzp, U, 0);
+            nzt = nzt_all(tgt_idx).';
+            Mblk = chnk.kernsplit.helm2d_close('sp', zk, ztgt, zsrc, nz, ...
+                                               wzp, LogC, CauC, [], nzt, awzp);
+
+        case {'dp','dprime','t'}
+            [LogC, ~, HypC] = chnk.kernsplit.wlchs_target( ...
+                endsa(ip), endsb(ip), ztgt, zsrc, nz, wzp, awzp, U, 0);
+            nzt = nzt_all(tgt_idx).';
+            Mblk = chnk.kernsplit.helm2d_close('dp', zk, ztgt, zsrc, nz, ...
+                                               wzp, LogC, [], HypC, nzt, awzp);
+
+        case {'c','combined'}
+            % combined kernel = coefs(1)*D + coefs(2)*S; near correction is
+            % the linear superposition of D and S near corrections (kernel
+            % split is linear in the kernel).
+            [LogC, CauC] = chnk.kernsplit.wlchs_target( ...
+                endsa(ip), endsb(ip), ztgt, zsrc, nz, wzp, awzp, U, 0);
+            Mblk_d = chnk.kernsplit.helm2d_close('d', zk, ztgt, zsrc, nz, wzp, LogC, CauC);
+            Mblk_s = chnk.kernsplit.helm2d_close('s', zk, ztgt, zsrc, nz, wzp, LogC, []) .* awzp;
+            Mblk = coefs(1) * Mblk_d + coefs(2) * Mblk_s;
+
+        case {'sc','spcombined'}
+            % combined kernel = coefs(1)*S' + coefs(2)*S; same linearity.
+            [LogC, CauC] = chnk.kernsplit.wlchs_target( ...
+                endsa(ip), endsb(ip), ztgt, zsrc, nz, wzp, awzp, U, 0);
+            nzt = nzt_all(tgt_idx).';
+            Mblk_sp = chnk.kernsplit.helm2d_close('sp', zk, ztgt, zsrc, nz, ...
+                                                  wzp, LogC, CauC, [], nzt, awzp);
+            Mblk_s  = chnk.kernsplit.helm2d_close('s', zk, ztgt, zsrc, nz, wzp, LogC, []) .* awzp;
+            Mblk = coefs(1) * Mblk_sp + coefs(2) * Mblk_s;
+
+        otherwise
+            error('helm2d_near_correction: unsupported type %s', type);
+    end
+
+    [I, J] = ndgrid(tgt_idx, src_idx);
+    ii = [ii; I(:)];
+    jj = [jj; J(:)];
+    vv = [vv; Mblk(:)];
+end
+
+delta = sparse(ii, jj, vv, ntgt, nsrc);
+end

--- a/chunkie/+chnk/+kernsplit/helm2d_panel_eval.m
+++ b/chunkie/+chnk/+kernsplit/helm2d_panel_eval.m
@@ -1,0 +1,153 @@
+function val = helm2d_panel_eval(chnkr, type, zk, dens, targets, dlim, eval_opts)
+%CHNK.HELSINGO.HELM2D_PANEL_EVAL  Helmholtz S/D/S' field evaluation
+% against a chunker via smooth Gauss-Legendre quadrature with per-panel
+% kernel-split close correction (wlchs_target).
+%
+% Designed to deliver 10+ digits of accuracy at any off-curve target,
+% including sub-deepest-panel distances near a corner -- the regime
+% where pure adaptive quadrature fails.
+%
+% Inputs:
+%   chnkr   - chunker (single connected sequence of panels). Coordinates
+%             must be in the SAME frame as targets (i.e., world coords).
+%   type    - 's' / 'single' for Helmholtz single-layer S = (i/4)H_0(zk r);
+%             'd' / 'double' for the double-layer D;
+%             'sp' / 'sprime' for the target-normal derivative S'
+%             (= ∂_{n_t} S) -- requires target normals.
+%   zk      - wavenumber.
+%   dens    - chnkr.npt x 1 (or row) density samples at chunker nodes.
+%   targets - either a 2 x nt real array (works for 's','d') or a struct
+%             with fields .r (2 x nt) and .n (2 x nt target normals,
+%             required for 'sp'/'sprime').
+%   dlim    - (optional, default 1.1) close-target threshold: a target
+%             is treated as "close" to a panel if its squared distance
+%             to the nearest panel node is < dlim^2 * panel_length^2.
+%
+% Output:
+%   val     - nt x 1 layer potential values at each target.
+
+if nargin < 6 || isempty(dlim); dlim = 1.1; end
+if nargin < 7; eval_opts = []; end
+
+% Normalize targets to a 2 x nt array of points; pull out target normals
+% if provided (needed for 'sp'/'sprime').
+if isstruct(targets)
+    if ~isfield(targets,'r')
+        error('CHNK.HELSINGO.HELM2D_PANEL_EVAL: targets struct lacks .r');
+    end
+    tgt_n = [];
+    if isfield(targets,'n') && ~isempty(targets.n)
+        tgt_n = targets.n;
+    end
+    targets = targets.r;
+else
+    tgt_n = [];
+end
+needs_tgt_normals = any(strcmpi(type, {'sp','sprime'}));
+if needs_tgt_normals && isempty(tgt_n)
+    error(['CHNK.HELSINGO.HELM2D_PANEL_EVAL: type ''%s'' requires ' ...
+           'target normals; pass targets as struct with .n field'], type);
+end
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+
+% complex coordinates
+zsrc_all = (chnkr.r(1,:,:) + 1i*chnkr.r(2,:,:));   % 1 x ngl x nch
+zsrc_all = zsrc_all(:).';                           % 1 x npt
+nz_all   = (chnkr.n(1,:,:) + 1i*chnkr.n(2,:,:));
+nz_all   = nz_all(:).';                             % 1 x npt
+% chunker stores d in dr/dt_chunker, where t_chunker is in [-1,1]; the
+% Gauss-Legendre weights w_GL are stored as wts/|d|. Here we use the
+% standard Legendre weights from lege.exps to reconstruct wzp = z'*w_GL.
+[~, wgl] = lege.exps(ngl);
+% awzp(i) = |d_i| * wgl_i (this is exactly chnkr.wts) and
+% wzp(i)  = d_i (complex) * wgl_i.
+awzp_all = chnkr.wts(:).';
+d_all    = (chnkr.d(1,:,:) + 1i*chnkr.d(2,:,:));   % 1 x ngl x nch
+d_all    = d_all(:).';                              % 1 x npt
+wgl_rep  = repmat(wgl(:).', 1, nch);                % 1 x npt
+wzp_all  = d_all .* wgl_rep;
+
+ztgt = targets(1,:).' + 1i*targets(2,:).';          % nt x 1
+
+dens = dens(:);
+
+% ---- smooth quadrature for all targets via chunkerkerneval
+% (FMM-acceleratable; avoids dense nt x npt allocation at large nt).
+switch lower(type)
+    case {'s','single'};       ker = kernel('helm','s', zk);
+    case {'d','double'};       ker = kernel('helm','d', zk);
+    case {'sp','sprime'};      ker = kernel('helm','sprime', zk);
+    otherwise
+        error('CHNK.HELSINGO.HELM2D_PANEL_EVAL: unknown type %s', type);
+end
+ck_opts = struct('forcesmooth', true);
+if isstruct(eval_opts) && isfield(eval_opts,'forcefmm') && eval_opts.forcefmm
+    ck_opts.forcefmm = true;
+else
+    % accel auto-switches to FMM at nt>200; force dense direct here.
+    ck_opts.accel = false;
+end
+if needs_tgt_normals
+    targobj_for_smooth = struct('r', targets, 'n', tgt_n);
+else
+    targobj_for_smooth = targets;
+end
+val = chunkerkerneval(chnkr, ker, dens, targobj_for_smooth, ck_opts);
+
+% complex target normals (for 'sp')
+if needs_tgt_normals
+    nzt_all = (tgt_n(1,:).' + 1i*tgt_n(2,:).');   % nt x 1
+end
+
+% ---- per-panel close correction
+% panel endpoints in complex form
+[rends,~] = chunkends(chnkr);          % dim x 2 x nch
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));     % nch x 1 (left ends)
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));     % nch x 1 (right ends)
+
+panlen = zeros(nch,1);
+for ip = 1:nch
+    panlen(ip) = sum(awzp_all((ip-1)*ngl+(1:ngl)));
+end
+panlen2 = (panlen).^2;
+dlim2   = dlim^2;
+
+for ip = 1:nch
+    pidx = (ip-1)*ngl + (1:ngl);
+    zsrc_p = zsrc_all(pidx);
+    nz_p   = nz_all(pidx);
+    wzp_p  = wzp_all(pidx);
+    awzp_p = awzp_all(pidx);
+    a      = endsa(ip);
+    b      = endsb(ip);
+
+    % screen targets close to this panel
+    diff_p = ztgt - zsrc_p;
+    d2_p   = real(diff_p).*real(diff_p) + imag(diff_p).*imag(diff_p);
+    dnear  = min(d2_p, [], 2);                       % nt x 1
+    near   = dnear < dlim2*panlen2(ip);
+    if ~any(near); continue; end
+
+    ztgt_near = ztgt(near);
+    U = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc_p);
+
+    switch lower(type)
+        case {'s','single'}
+            LogC = chnk.kernsplit.wlchs_target(a,b,ztgt_near,zsrc_p,nz_p,wzp_p,awzp_p,U,0);
+            Mclose = chnk.kernsplit.helm2d_close('s',zk,ztgt_near,zsrc_p,nz_p,wzp_p,LogC,[]);
+            val(near) = val(near) + Mclose * (awzp_p(:).*dens(pidx));
+        case {'d','double'}
+            [LogC, CauC] = chnk.kernsplit.wlchs_target(a,b,ztgt_near,zsrc_p,nz_p,wzp_p,awzp_p,U,0);
+            Mclose = chnk.kernsplit.helm2d_close('d',zk,ztgt_near,zsrc_p,nz_p,wzp_p,LogC,CauC);
+            val(near) = val(near) + Mclose * dens(pidx);
+        case {'sp','sprime'}
+            [LogC, CauC] = chnk.kernsplit.wlchs_target(a,b,ztgt_near,zsrc_p,nz_p,wzp_p,awzp_p,U,0);
+            nzt_near = nzt_all(near);
+            Mclose = chnk.kernsplit.helm2d_close('sp',zk,ztgt_near,zsrc_p,nz_p,wzp_p, ...
+                LogC, CauC, [], nzt_near, awzp_p);
+            val(near) = val(near) + Mclose * dens(pidx);
+    end
+end
+end

--- a/chunkie/+chnk/+kernsplit/helm2d_self_correction.m
+++ b/chunkie/+chnk/+kernsplit/helm2d_self_correction.m
@@ -1,0 +1,113 @@
+function [delta, U_src_cell] = helm2d_self_correction(chnkr, type, zk, U_src_cell)
+%CHNK.HELSINGO.HELM2D_SELF_CORRECTION  self-panel close-correction delta.
+%
+% Returns a sparse matrix `delta` such that the self-panel entries are the
+% kernel-split correction to add to smooth Gauss-Legendre quadrature.  This
+% ports testhelmos's SoperC_targ/ToperC_targ self-panel formulas to
+% chunkie's G = (i/4) H_0 convention.
+%
+% Supported types: 's', 'sp', 'dp'.  'd' returns zero (smooth GL is exact
+% on a smooth curve for D's diagonal limit).  Other types return zero too.
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+npt = chnkr.npt;
+
+tlow = lower(type);
+if ~ismember(tlow, {'s','single','sp','sprime','dp','dprime','t'})
+    delta = sparse(npt, npt);
+    return
+end
+
+[T, wgl] = lege.exps(ngl);
+[WfrakL, accept] = chnk.kernsplit.wfrak_log(ngl, 0, 1);
+if numel(accept) ~= ngl
+    error('helm2d_self_correction: self log moments should accept all GL nodes');
+end
+LogC0 = -log(abs(T(:) - T(:).'));
+LogC0(1:ngl+1:end) = 0;
+LogC0 = LogC0 + WfrakL ./ wgl(:).';
+
+[rends, ~] = chunkends(chnkr);
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));
+
+if nargin < 4 || isempty(U_src_cell)
+    U_src_cell = cell(1, nch);
+end
+
+gamma = 0.5772156649015328606;
+ii = [];
+jj = [];
+vv = [];
+
+for ip = 1:nch
+    idx = (ip-1)*ngl + (1:ngl);
+    zsrc = chnkr.r(1,:,ip) + 1i*chnkr.r(2,:,ip);
+    nz = chnkr.n(1,:,ip) + 1i*chnkr.n(2,:,ip);
+    dz = chnkr.d(1,:,ip) + 1i*chnkr.d(2,:,ip);
+    wzp = dz .* wgl(:).';
+    awzp = chnkr.wts(:,ip).';
+    logspd = log(abs(dz));
+
+    ztgt = zsrc(:);
+    nzt = nz(:);
+    zdiff = ztgt - zsrc;
+
+    switch tlow
+        case {'s','single'}
+            Mblk = -besselj(0, zk*abs(zdiff)) .* LogC0 / (2*pi);
+            Mblk = Mblk .* awzp;
+
+            tmp = 0.25i - (log(zk/2) + gamma) / (2*pi);
+            dval = (tmp - (diag(LogC0).' + logspd) / (2*pi)) .* awzp;
+
+        case {'sp','sprime'}
+            % Helsing demo12.m / demo13b.m Kadjoperinit, scaled by 1/2 for
+            % chunkie's G = (i/4) H_0 convention.
+            % Off-diagonal: smooth coefficient of log r is
+            %   (zk r) J_1(zk r) real(nzt/zdiff) awzp.
+            % Use besselj(1,·) directly so the formula handles complex zk.
+            tmp = zk * abs(zdiff);
+            cosNT = real(nzt ./ zdiff);     % NaN on the diagonal i=j
+            cosNT(1:ngl+1:end) = 0;          % clear diagonal: dval overwrites
+            Mblk = (tmp .* besselj(1,tmp) .* cosNT) .* LogC0 .* awzp / (2*pi);
+            % Diagonal: bare-kernel curvature limit S'(z,z) = -kappa/(4 pi).
+            % awzp(i)*S'(z_i, z_i) = -imag(zpp/zp)(i) * w(i) / (4 pi).
+            % chnkr.d2 -> z'' (canonical second derivative).
+            zpp = chnkr.d2(1,:,ip) + 1i*chnkr.d2(2,:,ip);
+            dval = -imag(zpp ./ dz) .* wgl(:).' / (4*pi);
+
+        case {'dp','dprime','t'}
+            tmp = zk * abs(zdiff);
+            Ta1 = zk^2 * besselj(1,tmp) ./ tmp .* real(nzt * conj(nz));
+            D1 = -real(nz ./ zdiff);
+            D2 =  real(nzt ./ zdiff);
+            Tb1 = tmp.^2 .* besselj(2,tmp) .* D1 .* D2;
+            Mblk = -(Ta1 + Tb1) .* LogC0 / (2*pi);
+            Mblk = Mblk .* awzp;
+
+            if isempty(U_src_cell{ip})
+                U_src_cell{ip} = chnk.kernsplit.wlchs_src_precomp( ...
+                    endsa(ip), endsb(ip), zsrc);
+            end
+            U_src = U_src_cell{ip};
+            [~, ~, HypC] = chnk.kernsplit.wlchs_target( ...
+                endsa(ip), endsb(ip), ztgt, zsrc, nz, wzp, awzp, U_src, 1);
+            Mblk = Mblk - real(nzt .* HypC) / (2*pi);
+
+            tmpdiag = 0.5i - (log(zk/2) + gamma - 0.5) / pi;
+            dval = zk^2 * 0.25 * ...
+                (tmpdiag - (diag(LogC0).' + logspd) / pi) .* awzp;
+            dval = dval - diag(real(nzt .* HypC) / (2*pi)).';
+    end
+
+    Mblk(1:ngl+1:end) = dval;
+    [I, J] = ndgrid(idx, idx);
+    ii = [ii; I(:)];
+    jj = [jj; J(:)];
+    vv = [vv; Mblk(:)];
+end
+
+delta = sparse(ii, jj, vv, npt, npt);
+end

--- a/chunkie/chunkerkerneval.m
+++ b/chunkie/chunkerkerneval.m
@@ -52,10 +52,10 @@ function [fints,ids] = chunkerkerneval(chnkobj,kern,dens,targobj,opts)
 %               between adaptive/smooth rule
 %       opts.eps = tolerance for adaptive integration
 %       opts.forcewlchs - if = true, use kernel-split (Helsing-style)
-%               panel quadrature for close evaluation. Supports Laplace
-%               (s/d/sp) scalar kernels -- kern must be a single kernel
-%               object. Delivers 10+ digits of accuracy at close
-%               off-curve targets. (false)
+%               panel quadrature for close evaluation. Supports
+%               Helmholtz (s/d/sp) and Laplace (s/d/sp) scalar kernels
+%               -- kern must be a single kernel object. Delivers 10+
+%               digits of accuracy at close off-curve targets. (false)
 %
 % output:
 %   fints - opdims(1) x nt array of integral values where opdims is the 
@@ -156,13 +156,14 @@ else
 end
 
 if use_wlchs
-    % Single scalar kernel (laplace, opdims=[1 1]).
+    % Single scalar kernel (helm/lap, opdims=[1 1]).
     if size(kern,1) ~= 1 || size(kern,2) ~= 1 || ~isa(kern,'kernel')
         error("CHUNKERKERNEVAL: forcewlchs=true requires a single kernel object");
     end
-    is_lap = strcmpi(kern.name, 'laplace');
-    if ~is_lap
-        error("CHUNKERKERNEVAL: forcewlchs supports Laplace kernels");
+    is_helm = strcmpi(kern.name, 'helmholtz');
+    is_lap  = strcmpi(kern.name, 'laplace');
+    if ~is_helm && ~is_lap
+        error("CHUNKERKERNEVAL: forcewlchs supports Helmholtz or Laplace kernels");
     end
     if ~ismember(lower(kern.type), {'s','single','d','double','sp','sprime'})
         error("CHUNKERKERNEVAL: forcewlchs currently supports only s/d/sp layers");
@@ -172,15 +173,31 @@ if use_wlchs
 
     src_probe = struct('r',[0;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
     tgt_probe = struct('r',[1;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
-    if strcmpi(wlchs_type,'s') || strcmpi(wlchs_type,'single')
-        tgt_probe.r = [2;0];
-        val_probe = kern.eval(src_probe, tgt_probe);
-        base_probe = -log(2)/(2*pi);
-    else
-        val_probe = kern.eval(src_probe, tgt_probe);
-        base_probe = 1/(2*pi);
+    val_probe = kern.eval(src_probe, tgt_probe);
+    if is_helm
+        if ~isfield(kern.params,'zk') || isempty(kern.params.zk)
+            error("CHUNKERKERNEVAL: forcewlchs Helmholtz requires kern.params.zk");
+        end
+        wlchs_zk = kern.params.zk;
+        if strcmpi(wlchs_type,'s') || strcmpi(wlchs_type,'single')
+            base_probe = 0.25i * besselh(0, wlchs_zk);
+        elseif strcmpi(wlchs_type,'d') || strcmpi(wlchs_type,'double')
+            base_probe = 0.25i * wlchs_zk * besselh(1, wlchs_zk);
+        else
+            base_probe = -0.25i * wlchs_zk * besselh(1, wlchs_zk);
+        end
+        wlchs_coef = val_probe / base_probe;
+    else  % laplace
+        wlchs_zk = [];
+        if strcmpi(wlchs_type,'s') || strcmpi(wlchs_type,'single')
+            tgt_probe.r = [2;0];
+            val_probe = kern.eval(src_probe, tgt_probe);
+            base_probe = -log(2)/(2*pi);
+        else
+            base_probe = 1/(2*pi);
+        end
+        wlchs_coef = val_probe / base_probe;
     end
-    wlchs_coef = val_probe / base_probe;
 
     % Non-rcipsav path: dispatch directly to kernsplit on the (possibly
     % merged) chunker. Targets pass through as raw point coords or struct
@@ -210,6 +227,9 @@ if use_wlchs
         targ_for_eval = targ_pts;
     end
     switch lower(wlchs_family)
+        case 'helmholtz'
+            fints = wlchs_coef * chnk.kernsplit.helm2d_panel_eval(chnkr_use, ...
+                wlchs_type, wlchs_zk, dens, targ_for_eval, [], hpe_opts);
         case 'laplace'
             fints = wlchs_coef * chnk.kernsplit.lap2d_panel_eval(chnkr_use, ...
                 wlchs_type, dens, targ_for_eval, [], hpe_opts);

--- a/chunkie/chunkermat.m
+++ b/chunkie/chunkermat.m
@@ -78,19 +78,22 @@ function [sysmat,varargout] = chunkermat(chnkobj,kern,opts,ilist)
 %                    different chunkers within rcip
 %           opts.eps = (1e-14) tolerance for adaptive quadrature
 %           opts.forcewlchs = kernel-split self/adjacent-panel correction
-%                    for Laplace S, D, S', D' kernels. After GGQ buildmat
-%                    fills self+adj with generic singular quadrature,
-%                    overwrite supported entries with wLCHS values from
+%                    for Helmholtz / Laplace S, D, S', D' kernels (and
+%                    Helmholtz combined 'c' = c1*D + c2*S, 'sc' = c1*S'
+%                    + c2*S kernels). After GGQ buildmat fills self+adj
+%                    with generic singular quadrature, overwrite
+%                    supported entries with wLCHS values from
 %                    chnk.kernsplit. Two forms supported:
 %                       opts.forcewlchs = true
-%                            (kern must be a single lap2d scalar kernel
-%                            of type 's', 'd', 'sp', or 'dp'; scalar
-%                            multiplier auto-extracted by probing).
-%                       opts.forcewlchs = struct('layout', L)
+%                            (kern must be a single helm2d or lap2d
+%                            scalar kernel; scalar multiplier auto-
+%                            extracted by probing).
+%                       opts.forcewlchs = struct('zk', zk, 'layout', L)
 %                            where L is an opdims(1)-by-opdims(2) cell
 %                            array; L{r,c} = [] for a zero block, or
 %                            {type, coef} / struct('type',t,'coef',a)
-%                            for a Laplace scalar kernel.
+%                            for a scalar kernel. zk required for
+%                            Helmholtz family entries.
 %  ilist - cell array of integer arrays ([]), list of panel interactions that
 %          should be ignored when constructing matrix entries or quadrature
 %          corrections. 
@@ -329,6 +332,35 @@ for i = 1:nchunkers
 
             if (~nonsmoothonly)
                 sysmat_tmp = ftmp(chnkrj,chnkri).*wts;
+            end
+
+            % Cross-chunker (i ~= j) near-corner correction via wLCHS.
+            % When forcewlchs is enabled and the (i,j) block kernel is a
+            % recognized scalar/combined Helmholtz type, add the kernel-
+            % split close-evaluation delta from helm2d_near_correction.
+            % The proximity check inside that function filters out non-
+            % near (i,j) pairs, so chunker pairs that don't meet at a
+            % corner contribute zero.
+            if ~isempty(forcewlchs_opt) && ~nonsmoothonly && all(opdims == 1)
+                if size(kern,1) == 1 && size(kern,2) == 1
+                    bk = kern;
+                else
+                    bk = kern(i,j);
+                end
+                [near_type, near_coef] = chunkermat_kernel_for_near(bk);
+                if ~isempty(near_type)
+                    if any(strcmp(near_type, {'c','combined','sc','spcombined'}))
+                        delta_near = chnk.kernsplit.helm2d_near_correction( ...
+                            chnkrj, chnkri, near_type, bk.params.zk, [], near_coef);
+                    else
+                        delta_near = chnk.kernsplit.helm2d_near_correction( ...
+                            chnkrj, chnkri, near_type, bk.params.zk);
+                        delta_near = near_coef * delta_near;
+                    end
+                    if nnz(delta_near) > 0
+                        sysmat_tmp = sysmat_tmp + full(delta_near);
+                    end
+                end
             end
 
             if adaptive_correction
@@ -788,8 +820,8 @@ end
 
 
 function sysmat = chunkermat_apply_wlchs_adj(sysmat, chnkr, opdims, kern, fw, nonsmoothonly)
-% Apply wLCHS self/adjacent-panel corrections to sysmat for Laplace
-% S/D/Sp/Dp entries. See chunkermat opts.forcewlchs comment.
+% Apply wLCHS self/adjacent-panel corrections to sysmat for Helmholtz /
+% Laplace S/D/Sp/Dp entries. See chunkermat opts.forcewlchs comment.
 %
 % Behaviour depends on nonsmoothonly:
 %   false (default) - sysmat is dense; ENTRIES on self+adj blocks are
@@ -804,12 +836,17 @@ if nargin < 6 || isempty(nonsmoothonly), nonsmoothonly = false; end
 
 % Decode forcewlchs spec: build a 2D cell `layout` (opdims(1) x opdims(2))
 % where layout{r,c} is either [] (no wLCHS, leave entry alone), or
-% struct('type', t, 'coef', a, 'family', 'laplace').
+% struct('type', t, 'coef', a, 'zk', zk, 'family', 'helmholtz'|'laplace').
+% Helmholtz types: s, d, sp, dp, t, c, sc. Laplace types: s, d, sp, dp
+% (no combined kernels). zk is unused/ignored for Laplace.
 m = opdims(1); n = opdims(2);
 layout = cell(m, n);
+helm_types = {'s','single','d','double','sp','sprime','dp','dprime', ...
+              'c','combined','sc','spcombined'};
 lap_types  = {'s','single','d','double','sp','sprime','dp','dprime'};
 if islogical(fw) || (isnumeric(fw) && isscalar(fw))
-    % Boolean form: kern must be a single scalar Laplace kernel, or zero.
+    % Boolean form: kern must be a single scalar Helmholtz or Laplace
+    % kernel, or a zero kernel (no-op).
     if ~fw, return; end
     if isa(kern, 'kernel') && (strcmpi(kern.name, 'zeros') || ...
             (isprop(kern, 'iszero') && kern.iszero))
@@ -817,28 +854,55 @@ if islogical(fw) || (isnumeric(fw) && isscalar(fw))
     end
     fam = wlchs_kernel_family(kern);
     if isempty(fam)
-        error("chunkermat: opts.forcewlchs=true requires a single lap2d kernel");
+        error("chunkermat: opts.forcewlchs=true requires a single helm2d or lap2d kernel");
     end
     t = lower(kern.type);
     if m ~= 1 || n ~= 1
-        error("chunkermat: opts.forcewlchs=true requires a single scalar (opdims=[1 1]) lap kernel");
+        error("chunkermat: opts.forcewlchs=true requires a single scalar (opdims=[1 1]) helm or lap kernel");
     end
-    if ~ismember(t, lap_types)
-        error("chunkermat: opts.forcewlchs=true: lap kernel type %s not supported", kern.type);
+    if strcmp(fam, 'helmholtz')
+        if ~ismember(t, helm_types)
+            error("chunkermat: opts.forcewlchs=true: helm kernel type %s not supported", kern.type);
+        end
+        if ~isfield(kern.params, 'zk') || isempty(kern.params.zk)
+            error("chunkermat: opts.forcewlchs requires kern.params.zk");
+        end
+        zk = kern.params.zk;
+    else  % laplace
+        if ~ismember(t, lap_types)
+            error("chunkermat: opts.forcewlchs=true: lap kernel type %s not supported", kern.type);
+        end
+        zk = [];
     end
-    coef = wlchs_extract_scalar(kern, t, fam);
-    layout{1,1} = struct('type', t, 'coef', coef, 'family', fam);
+    if strcmpi(t, 'c') || strcmpi(t, 'combined')
+        if ~isfield(kern.params, 'coefs') || isempty(kern.params.coefs)
+            error("chunkermat: forcewlchs c kernel requires kern.params.coefs");
+        end
+        layout{1,1} = struct('type', 'c', 'coefs', kern.params.coefs(:).', 'zk', zk, 'family', fam);
+    elseif strcmpi(t, 'sc') || strcmpi(t, 'spcombined')
+        if ~isfield(kern.params, 'coefs') || isempty(kern.params.coefs)
+            error("chunkermat: forcewlchs sc kernel requires kern.params.coefs");
+        end
+        layout{1,1} = struct('type', 'sc', 'coefs', kern.params.coefs(:).', 'zk', zk, 'family', fam);
+    else
+        coef = wlchs_extract_scalar(kern, t, zk, fam);
+        layout{1,1} = struct('type', t, 'coef', coef, 'zk', zk, 'family', fam);
+    end
 elseif isstruct(fw)
     if ~isfield(fw, 'layout')
         error("chunkermat: opts.forcewlchs struct needs field 'layout'");
     end
-    fam_default = 'laplace';
+    % Top-level defaults; per-entry struct can override family / zk.
+    fam_default = 'helmholtz';
     if isfield(fw, 'family') && ~isempty(fw.family)
         fam_default = lower(fw.family);
     end
-    if ~strcmp(fam_default, 'laplace')
-        error("chunkermat: opts.forcewlchs.family must be 'laplace'");
+    if ~ismember(fam_default, {'helmholtz','laplace'})
+        error("chunkermat: opts.forcewlchs.family must be 'helmholtz' or 'laplace'");
     end
+    zk_default = [];
+    if isfield(fw, 'zk') && ~isempty(fw.zk), zk_default = fw.zk; end
+
     L = fw.layout;
     if ~iscell(L) || size(L,1) ~= m || size(L,2) ~= n
         error("chunkermat: opts.forcewlchs.layout must be %dx%d cell", m, n);
@@ -847,19 +911,58 @@ elseif isstruct(fw)
         for c = 1:n
             entry = L{r,c};
             if isempty(entry); continue; end
+            ent_fam = fam_default;
+            ent_zk  = zk_default;
             if iscell(entry)
                 t = entry{1}; a = entry{2};
             elseif isstruct(entry)
                 t = entry.type;
-                a = entry.coef;
+                if isfield(entry, 'coefs') && ~isempty(entry.coefs)
+                    a = entry.coefs;
+                else
+                    a = entry.coef;
+                end
+                if isfield(entry, 'family') && ~isempty(entry.family)
+                    ent_fam = lower(entry.family);
+                end
+                if isfield(entry, 'zk') && ~isempty(entry.zk), ent_zk = entry.zk; end
             else
                 error("chunkermat: opts.forcewlchs.layout{%d,%d} bad form", r, c);
             end
             if strcmpi(t, 'zero'); continue; end
-            if ~ismember(lower(t), lap_types)
-                error("chunkermat: forcewlchs (laplace): layout entry type %s not supported", t);
+
+            switch ent_fam
+                case 'helmholtz'
+                    allowed_e = {'s','single','d','double','sp','sprime','dp','dprime', ...
+                                 't','c','combined','sc','spcombined'};
+                    if isempty(ent_zk)
+                        error("chunkermat: forcewlchs helm layout entry (%d,%d) needs zk", r, c);
+                    end
+                case 'laplace'
+                    allowed_e = lap_types;
+                otherwise
+                    error("chunkermat: unknown family %s", ent_fam);
             end
-            layout{r,c} = struct('type', lower(t), 'coef', a, 'family', 'laplace');
+            if ~ismember(lower(t), allowed_e)
+                error("chunkermat: forcewlchs (%s): layout entry type %s not supported", ent_fam, t);
+            end
+
+            if strcmpi(t, 'c') || strcmpi(t, 'combined')
+                if ~isvector(a) || numel(a) ~= 2
+                    error("chunkermat: forcewlchs c layout entry needs coefs [c1, c2]");
+                end
+                layout{r,c} = struct('type', 'c', 'coefs', a(:).', ...
+                                     'zk', ent_zk, 'family', ent_fam);
+            elseif strcmpi(t, 'sc') || strcmpi(t, 'spcombined')
+                if ~isvector(a) || numel(a) ~= 2
+                    error("chunkermat: forcewlchs sc layout entry needs coefs [c1, c2]");
+                end
+                layout{r,c} = struct('type', 'sc', 'coefs', a(:).', ...
+                                     'zk', ent_zk, 'family', ent_fam);
+            else
+                layout{r,c} = struct('type', lower(t), 'coef', a, ...
+                                     'zk', ent_zk, 'family', ent_fam);
+            end
         end
     end
 else
@@ -879,24 +982,70 @@ for r = 1:m
         spec = layout{r,c};
         if isempty(spec); continue; end
 
+        is_c  = strcmpi(spec.type, 'c')  || strcmpi(spec.type, 'combined');
+        is_sc = strcmpi(spec.type, 'sc') || strcmpi(spec.type, 'spcombined');
+        is_split = is_c || is_sc;
+
         % --- Self-panel correction ---
+        % Plain scalar kernels: spec.coef * delta_self(spec.type)
+        % Combined 'c' = c1*D + c2*S:   c2 * delta_self('s') for helm
+        %                               (Helm D has no self correction).
+        % Combined 'sc' = c1*S' + c2*S: c1*delta_self('sp') + c2*delta_self('s')
+        % (Combined kernels are Helmholtz-only.)
         if wlchs_has_self_correction(spec.type, spec.family)
-            [delta_self_a, U_src_cell] = wlchs_self_correction_dispatch( ...
-                spec, chnkr, spec.type, U_src_cell);
-            self_coef_a = spec.coef;
+            if is_c
+                c1 = spec.coefs(1); c2 = spec.coefs(2);
+                delta_self_a = []; delta_self_b = [];
+                if c2 ~= 0
+                    [delta_self_a, U_src_cell] = wlchs_self_correction_dispatch( ...
+                        spec, chnkr, 's', U_src_cell);
+                end
+                self_coef_a = c2; self_coef_b = 0;
+            elseif is_sc
+                c1 = spec.coefs(1); c2 = spec.coefs(2);
+                delta_self_a = []; delta_self_b = [];
+                if c1 ~= 0
+                    [delta_self_a, U_src_cell] = wlchs_self_correction_dispatch( ...
+                        spec, chnkr, 'sp', U_src_cell);
+                end
+                if c2 ~= 0
+                    [delta_self_b, U_src_cell] = wlchs_self_correction_dispatch( ...
+                        spec, chnkr, 's', U_src_cell);
+                end
+                self_coef_a = c1; self_coef_b = c2;
+            else
+                [delta_self_a, U_src_cell] = wlchs_self_correction_dispatch( ...
+                    spec, chnkr, spec.type, U_src_cell);
+                delta_self_b = [];
+                self_coef_a = spec.coef; self_coef_b = 0;
+            end
             for ich = 1:chnkr.nch
                 ji = (1:ngl).' + (ich-1)*ngl;
                 rows_blk = (ji - 1) * m + r;
                 cols_blk = (ji.' - 1) * n + c;
-                d_blk = self_coef_a * full(delta_self_a(ji, ji));
+                d_blk = zeros(ngl, ngl);
+                if ~isempty(delta_self_a)
+                    d_blk = d_blk + self_coef_a * full(delta_self_a(ji, ji));
+                end
+                if ~isempty(delta_self_b)
+                    d_blk = d_blk + self_coef_b * full(delta_self_b(ji, ji));
+                end
                 if nonsmoothonly
                     sysmat(rows_blk, cols_blk) = d_blk;
                 else
-                    Kb = wlchs_kernel_eval(spec, spec.type, ...
-                        chnkr.r(:,:,ich), chnkr.n(:,:,ich), ...
-                        chnkr.r(:,:,ich), chnkr.n(:,:,ich));
-                    awzp = chnkr.wts(:, ich).';
-                    M_smooth = spec.coef * (Kb .* awzp);
+                    if is_split
+                        Kb = wlchs_kernel_eval(spec, spec.type, ...
+                            chnkr.r(:,:,ich), chnkr.n(:,:,ich), ...
+                            chnkr.r(:,:,ich), chnkr.n(:,:,ich), spec.coefs);
+                        awzp = chnkr.wts(:, ich).';
+                        M_smooth = (Kb .* awzp);
+                    else
+                        Kb = wlchs_kernel_eval(spec, spec.type, ...
+                            chnkr.r(:,:,ich), chnkr.n(:,:,ich), ...
+                            chnkr.r(:,:,ich), chnkr.n(:,:,ich));
+                        awzp = chnkr.wts(:, ich).';
+                        M_smooth = spec.coef * (Kb .* awzp);
+                    end
                     M_smooth(1:ngl+1:end) = 0;
                     sysmat(rows_blk, cols_blk) = M_smooth + d_blk;
                 end
@@ -904,9 +1053,36 @@ for r = 1:m
         end
 
         % --- Adjacent-panel correction ---
-        [delta_a, U_src_cell] = wlchs_adj_correction_dispatch( ...
-            spec, chnkr, spec.type, U_src_cell);
-        adj_coef_a = spec.coef;
+        delta_a = []; delta_b = [];
+        adj_coef_a = 0; adj_coef_b = 0;
+        if is_c
+            c1 = spec.coefs(1); c2 = spec.coefs(2);
+            if c1 ~= 0
+                [delta_a, U_src_cell] = wlchs_adj_correction_dispatch( ...
+                    spec, chnkr, 'd', U_src_cell);
+            end
+            if c2 ~= 0
+                [delta_b, U_src_cell] = wlchs_adj_correction_dispatch( ...
+                    spec, chnkr, 's', U_src_cell);
+            end
+            adj_coef_a = c1; adj_coef_b = c2;
+        elseif is_sc
+            c1 = spec.coefs(1); c2 = spec.coefs(2);
+            if c1 ~= 0
+                [delta_a, U_src_cell] = wlchs_adj_correction_dispatch( ...
+                    spec, chnkr, 'sp', U_src_cell);
+            end
+            if c2 ~= 0
+                [delta_b, U_src_cell] = wlchs_adj_correction_dispatch( ...
+                    spec, chnkr, 's', U_src_cell);
+            end
+            adj_coef_a = c1; adj_coef_b = c2;
+        else
+            [delta_a, U_src_cell] = wlchs_adj_correction_dispatch( ...
+                spec, chnkr, spec.type, U_src_cell);
+            adj_coef_a = spec.coef;
+        end
+
         for ich = 1:chnkr.nch
             for io = 1:2
                 jch = chnkr.adj(io, ich);
@@ -915,15 +1091,29 @@ for r = 1:m
                 jcols = (jch-1)*ngl + (1:ngl);
                 rows_blk = (ji - 1) * m + r;
                 cols_blk = (jcols - 1) * n + c;
-                d_blk = adj_coef_a * full(delta_a(ji, jcols));
+                d_blk = zeros(ngl, ngl);
+                if ~isempty(delta_a)
+                    d_blk = d_blk + adj_coef_a * full(delta_a(ji, jcols));
+                end
+                if ~isempty(delta_b)
+                    d_blk = d_blk + adj_coef_b * full(delta_b(ji, jcols));
+                end
                 if nonsmoothonly
                     sysmat(rows_blk, cols_blk) = d_blk;
                 else
-                    Kb = wlchs_kernel_eval(spec, spec.type, ...
-                        chnkr.r(:,:,jch), chnkr.n(:,:,jch), ...
-                        chnkr.r(:,:,ich), chnkr.n(:,:,ich));
-                    awzp = chnkr.wts(:, jch).';
-                    M_smooth = spec.coef * (Kb .* awzp);
+                    if is_split
+                        Kb = wlchs_kernel_eval(spec, spec.type, ...
+                            chnkr.r(:,:,jch), chnkr.n(:,:,jch), ...
+                            chnkr.r(:,:,ich), chnkr.n(:,:,ich), spec.coefs);
+                        awzp = chnkr.wts(:, jch).';
+                        M_smooth = (Kb .* awzp);
+                    else
+                        Kb = wlchs_kernel_eval(spec, spec.type, ...
+                            chnkr.r(:,:,jch), chnkr.n(:,:,jch), ...
+                            chnkr.r(:,:,ich), chnkr.n(:,:,ich));
+                        awzp = chnkr.wts(:, jch).';
+                        M_smooth = spec.coef * (Kb .* awzp);
+                    end
                     sysmat(rows_blk, cols_blk) = M_smooth + d_blk;
                 end
             end
@@ -933,17 +1123,26 @@ end
 end
 
 function fam = wlchs_kernel_family(kern)
-% Returns 'laplace' or '' if the kernel is unsupported by the wLCHS path.
+% Returns 'helmholtz', 'laplace', or '' if the kernel is unsupported by
+% the wLCHS path.
 fam = '';
 if ~isa(kern, 'kernel'), return; end
 if strcmpi(kern.name, 'zeros'), return; end
-if strcmpi(kern.name, 'laplace'), fam = 'laplace'; return; end
+if strcmpi(kern.name, 'helmholtz'), fam = 'helmholtz'; return; end
+if strcmpi(kern.name, 'laplace'),   fam = 'laplace';   return; end
 end
 
 function tf = wlchs_has_self_correction(type, family)
+% Helmholtz: S, S', D', T, combined kernels have self corrections; D does
+% not (the J_1 piece of D vanishes on the diagonal at smooth boundary
+% points). For combined 'c' = c1*D + c2*S we return true and let the
+% application step multiply c2 (zero if S is absent); same idea for 'sc'.
 % Laplace: S, D, S', D' all have nontrivial self corrections.
-if nargin < 2 || isempty(family), family = 'laplace'; end
+if nargin < 2 || isempty(family), family = 'helmholtz'; end
 switch lower(family)
+    case 'helmholtz'
+        tf = ismember(lower(type), {'s','single','sp','sprime','dp','dprime','t', ...
+                                    'c','combined','sc','spcombined'});
     case 'laplace'
         tf = ismember(lower(type), {'s','single','d','double','sp','sprime','dp','dprime'});
     otherwise
@@ -952,7 +1151,12 @@ end
 end
 
 function [delta, U_src_cell] = wlchs_self_correction_dispatch(spec, chnkr, type, U_src_cell)
+% Dispatch self-panel correction to the right kernel family. The `type`
+% argument is passed explicitly because combined kernels (Helm 'c'/'sc')
+% issue per-component calls with types differing from spec.type.
 switch lower(spec.family)
+    case 'helmholtz'
+        [delta, U_src_cell] = chnk.kernsplit.helm2d_self_correction(chnkr, type, spec.zk, U_src_cell);
     case 'laplace'
         [delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction(chnkr, type, U_src_cell);
     otherwise
@@ -962,6 +1166,8 @@ end
 
 function [delta, U_src_cell] = wlchs_adj_correction_dispatch(spec, chnkr, type, U_src_cell)
 switch lower(spec.family)
+    case 'helmholtz'
+        [delta, U_src_cell] = chnk.kernsplit.helm2d_adj_correction(chnkr, type, spec.zk, U_src_cell);
     case 'laplace'
         [delta, U_src_cell] = chnk.kernsplit.lap2d_adj_correction(chnkr, type, U_src_cell);
     otherwise
@@ -971,9 +1177,30 @@ end
 
 function K = wlchs_kernel_eval(spec, type, src_r, src_n, tgt_r, tgt_n, varargin)
 % Evaluate the bare kernel of given family/type at (src, tgt) GL nodes.
+% For combined types, varargin{1} = coefs = [c1, c2] (Helmholtz only).
 si.r = src_r; si.n = src_n;
 ti.r = tgt_r; ti.n = tgt_n;
 switch lower(spec.family)
+    case 'helmholtz'
+        zk = spec.zk;
+        switch lower(type)
+            case {'s','single'},      K = chnk.helm2d.kern(zk, si, ti, 's');
+            case {'d','double'},      K = chnk.helm2d.kern(zk, si, ti, 'd');
+            case {'sp','sprime'},     K = chnk.helm2d.kern(zk, si, ti, 'sprime');
+            case {'dp','dprime','t'}, K = chnk.helm2d.kern(zk, si, ti, 'dprime');
+            case {'c','combined'}
+                if isempty(varargin)
+                    error('wlchs_kernel_eval: c kernel requires coefs');
+                end
+                K = chnk.helm2d.kern(zk, si, ti, 'c', varargin{1});
+            case {'sc','spcombined'}
+                if isempty(varargin)
+                    error('wlchs_kernel_eval: sc kernel requires coefs');
+                end
+                K = chnk.helm2d.kern(zk, si, ti, 'sc', varargin{1});
+            otherwise
+                error('wlchs_kernel_eval: helm type %s not supported', type);
+        end
     case 'laplace'
         switch lower(type)
             case {'s','single'},  K = chnk.lap2d.kern(si, ti, 's');
@@ -988,16 +1215,39 @@ switch lower(spec.family)
 end
 end
 
-function coef = wlchs_extract_scalar(kern, t, family)
+function coef = wlchs_extract_scalar(kern, t, param, family)
 % Probe the kern eval at a known src/tgt pair, divide by analytic value.
 % Result is the scalar prefactor on top of the bare kernel (=1 for plain
-% kernel('lap',type); !=1 for scalar-multiplied kernels). For Laplace S
-% the bare value at r=1 is 0 (log 1 = 0), so we probe at r=2 instead.
-if nargin < 3 || isempty(family), family = 'laplace'; end
-src_probe = struct('r',[0;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
-tgt_probe = struct('r',[2;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
+% kernel('lap',type) or kernel('helm',type,zk); !=1 for scalar-multiplied
+% kernels). For Laplace S the bare value at r=1 is 0 (log 1 = 0), so we
+% probe at r=2 instead.
+%
+% `param` carries family-specific data (zk for helmholtz, [] for laplace).
+if nargin < 4 || isempty(family), family = 'helmholtz'; end
+if strcmp(family, 'laplace')
+    src_probe = struct('r',[0;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
+    tgt_probe = struct('r',[2;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
+else
+    src_probe = struct('r',[0;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
+    tgt_probe = struct('r',[1;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
+end
 val = kern.eval(src_probe, tgt_probe);
 switch lower(family)
+    case 'helmholtz'
+        zk = param;
+        switch lower(t)
+            case {'s','single'}
+                base = 0.25i * besselh(0, zk);
+            case {'d','double'}
+                base = 0.25i * zk * besselh(1, zk);
+            case {'sp','sprime'}
+                base = kernel('helm','sp', zk).eval(src_probe, tgt_probe);
+            case {'dp','dprime'}
+                base = kernel('helm','dp', zk).eval(src_probe, tgt_probe);
+            otherwise
+                error('wlchs_extract_scalar: helm type %s not supported', t);
+        end
+        coef = val / base;
     case 'laplace'
         switch lower(t)
             case {'s','single'},  base = chnk.lap2d.kern(src_probe, tgt_probe, 's');
@@ -1010,5 +1260,33 @@ switch lower(family)
         coef = val / base;
     otherwise
         error('wlchs_extract_scalar: unsupported family %s', family);
+end
+end
+
+
+function [near_type, near_coef] = chunkermat_kernel_for_near(kern)
+% Inspect a kernel object and return (type, coef-or-coefs) suitable for
+% calling chnk.kernsplit.helm2d_near_correction. Returns empty type for
+% unsupported kernels (zero kernel, custom types, etc.).
+near_type = ''; near_coef = [];
+if ~isa(kern, 'kernel'); return; end
+if strcmpi(kern.name, 'zeros') || (isprop(kern,'iszero') && kern.iszero)
+    return;
+end
+if ~strcmpi(kern.name, 'helmholtz'); return; end
+if ~isfield(kern.params, 'zk') || isempty(kern.params.zk); return; end
+zk_l = kern.params.zk;
+t = lower(kern.type);
+switch t
+    case {'s','single','d','double','sp','sprime','dp','dprime','t'}
+        near_type = t;
+        near_coef = wlchs_extract_scalar(kern, t, zk_l, 'helmholtz');
+    case {'c','combined'}
+        if isfield(kern.params, 'coefs') && numel(kern.params.coefs) == 2
+            near_type = 'c';
+            near_coef = kern.params.coefs(:).';
+        end
+    otherwise
+        % unsupported (custom sum kernels with no recognized type)
 end
 end

--- a/devtools/test/chunkermat_helm_forcewlchsTest.m
+++ b/devtools/test/chunkermat_helm_forcewlchsTest.m
@@ -1,0 +1,56 @@
+function chunkermat_helm_forcewlchsTest()
+%CHUNKERMAT_HELM_FORCEWLCHSTEST  Verify chunkermat opts.forcewlchs dispatches
+%   correctly to chnk.kernsplit Helmholtz self/adj corrections (s, d, sp).
+%
+%   On a smooth closed curve, the wLCHS quadrature and chunkermat's default
+%   GGQ quadrature should agree in their action on a smooth density.
+%   Comparison tolerance ~1e-12 (limited by GGQ).
+
+zk = 1.1;
+cparams = []; cparams.ta = 0; cparams.tb = 2*pi; cparams.ifclosed = true;
+cparams.maxchunklen = 2*pi/8;
+pref = []; pref.k = 16;
+chnkr = chunkerfunc(@(t) circle_param(t), cparams, pref);
+N = chnkr.npt;
+
+% Smooth density: complex exponential along the boundary.
+theta = atan2(chnkr.r(2,:), chnkr.r(1,:));
+sig = exp(2i*theta(:));
+
+types = {'s','d','sp','dp'};
+% Tolerances reflect GGQ quadrature accuracy (the reference); wlchs is
+% typically more accurate. dp is hypersingular so GGQ tolerance is loose.
+tols  = [1e-11 1e-11 1e-10 1e-6];
+for it = 1:numel(types)
+    t = types{it};
+    K = kernel('helm', t, zk);
+    A_ref = chunkermat(chnkr, K);
+    A_wl  = chunkermat(chnkr, K, struct('forcewlchs',true));
+    diff = norm((A_ref - A_wl) * sig, 'inf');
+    fprintf('  helm %-3s: ||(A_ggq - A_wlchs)*sig||_inf = %.3e\n', t, diff);
+    assert(diff < tols(it), 'Helmholtz wlchs %s mismatch %.3e exceeds %.1e', ...
+        t, diff, tols(it));
+end
+
+% Scalar-multiplied kernel: 3.7 * S
+kern_scaled = 3.7 * kernel('helm','s',zk);
+A_ref = chunkermat(chnkr, kern_scaled);
+A_wl  = chunkermat(chnkr, kern_scaled, struct('forcewlchs',true));
+diff = norm((A_ref - A_wl) * sig, 'inf');
+fprintf('  3.7*s   : ||(A_ggq - A_wlchs)*sig||_inf = %.3e\n', diff);
+assert(diff < 1e-11);
+
+% Combined kernels ('c' = c1*D + c2*S, 'sc' = c1*S' + c2*S) are also
+% supported in the layout dispatch, but their self block requires RCIP
+% corrections for full accuracy -- they are exercised in the helmopensurface
+% tests of the open-arc Helmholtz PR.
+
+fprintf('PASS: chunkermat forcewlchs helm dispatch verified for s/d/sp/dp/scaled\n');
+end
+
+function [r, d, d2] = circle_param(t)
+ct = cos(t); st = sin(t);
+r  = [ct(:).';  st(:).'];
+d  = [-st(:).'; ct(:).'];
+d2 = [-ct(:).'; -st(:).'];
+end


### PR DESCRIPTION
## Summary
Builds on the Laplace forcewlchs framework (#172) and adds Helmholtz S, D, S', D' kernsplit support to `chunkermat` and `chunkerkerneval`, plus combined kernels (`c` = c1·D + c2·S, `sc` = c1·S' + c2·S) for the impedance-style boundary integral formulations used in open-arc Helmholtz.

## What's included
- **New `chnk.kernsplit` Helmholtz routines**: `helm2d_self_correction`, `helm2d_adj_correction`, `helm2d_panel_eval`, `helm2d_close`, `helm2d_near_correction`.
- **`chunkermat` (`forcewlchs`)**:
  - `wlchs_kernel_family`, `wlchs_has_self_correction`, `wlchs_self_correction_dispatch`, `wlchs_adj_correction_dispatch`, `wlchs_kernel_eval`, `wlchs_extract_scalar` extended with Helmholtz cases (`zk` passed through `spec.zk`).
  - **Combined kernels**: type `c` and `sc` decompose into per-component (D/S or S'/S) self/adjacent corrections.
  - **Cross-chunker near-corner correction**: when forcewlchs is enabled on a multi-chunker problem, recognized Helmholtz block kernels get `chnk.kernsplit.helm2d_near_correction` added on top of smooth GL (zero on non-adjacent chunker pairs). New `chunkermat_kernel_for_near` helper.
- **`chunkerkerneval` (`forcewlchs`)**: Helmholtz decode (`zk` required) with bessel-h coefficient probing; dispatches to `helm2d_panel_eval` alongside Laplace.

## Test plan
- [x] `devtools/test/chunkermat_helm_forcewlchsTest.m` (new) — verifies `forcewlchs` Helmholtz s/d/sp/dp/scalar agree with GGQ to GGQ precision on the unit circle (`~1e-11` for s/d/sp, `~1e-7` for the hypersingular dp).
- [x] Laplace regression (`chunkermat_lap_forcewlchsTest`) still passes on this branch.

## Notes
- Combined Helmholtz kernels (`c`, `sc`) are dispatched correctly but their self block requires RCIP corrections for full accuracy — they're exercised in the helmopensurface tests of the open-arc Helmholtz PR (PR 3 in this stack).
- Stacked on #172. PR 1b of 6.
- Original implementation contributed by @sj90101.
