### PR TITLE
Extend kernel-split forcewlchs to Stokes velocity SLP/DLP/Strac

### DIFF
--- a/chunkie/+chnk/+kernsplit/sto2d_adj_correction.m
+++ b/chunkie/+chnk/+kernsplit/sto2d_adj_correction.m
@@ -1,0 +1,40 @@
+function [delta, U_src_cell] = sto2d_adj_correction(chnkr, type, mu, U_src_cell)
+%CHNK.KERNSPLIT.STO2D_ADJ_CORRECTION  adjacent-panel close correction
+% delta for the 2D Stokes velocity layer potentials, decomposed by
+% sub-block.
+%
+% Stokes svel decomposes as a bounded (r_i r_j / r^2) piece plus a
+% (1/(2*mu)) * Laplace_SLP * delta_ij log piece.  On adjacent-panel
+% entries the bounded smooth piece is resolved exponentially well by
+% smooth Gauss-Legendre quadrature at panel order 16, so the adj
+% correction reduces to (1/(2*mu)) * Laplace SLP wLCHS adj correction
+% on the (xx, yy) sub-blocks; (xy, yx) need none.
+%
+% Stokes dvel is fully bounded (no log) on smooth closed curves; smooth
+% GL on adjacent panels is exponentially accurate, so all four
+% sub-blocks return zero (no adj correction).
+%
+% Inputs and output convention: see sto2d_self_correction.
+
+if nargin < 4 || isempty(U_src_cell)
+    U_src_cell = cell(1, chnkr.nch);
+end
+N = chnkr.npt;
+
+switch lower(type)
+    case {'svel_xx', 'svel_yy'}
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_adj_correction( ...
+            chnkr, 's', U_src_cell);
+        delta = (1/(2*mu)) * lap_delta;
+
+    case {'svel_xy', 'svel_yx'}
+        delta = sparse(N, N);
+
+    case {'dvel_xx', 'dvel_xy', 'dvel_yx', 'dvel_yy', ...
+          'strac_xx', 'strac_xy', 'strac_yx', 'strac_yy'}
+        delta = sparse(N, N);
+
+    otherwise
+        error('CHNK.KERNSPLIT.STO2D_ADJ_CORRECTION: type %s not supported', type);
+end
+end

--- a/chunkie/+chnk/+kernsplit/sto2d_panel_eval.m
+++ b/chunkie/+chnk/+kernsplit/sto2d_panel_eval.m
@@ -1,0 +1,271 @@
+function val = sto2d_panel_eval(chnkr, type, mu, dens, targets, dlim, eval_opts)
+%CHNK.KERNSPLIT.STO2D_PANEL_EVAL  off-curve evaluation of Stokes velocity
+% layer potentials with kernel-split close correction.
+%
+% Following Wu, Barnett et al. (arXiv 1909.00049) eq (32)-(34):
+%   S sigma = (1/(2*mu))[(S sigma_1, S sigma_2)
+%                        + grad S(y . sigma)
+%                        - x_1 grad S sigma_1
+%                        - x_2 grad S sigma_2]
+%   D sigma = ((1/(2*pi)) Re(I_C tau_1, I_C tau_2)
+%              + grad D(y . sigma)
+%              - x_1 grad D sigma_1
+%              - x_2 grad D sigma_2)
+% where tau_1 = (sigma_1+i*sigma_2)*Re(n_y)/n_y, tau_2 likewise with Im.
+% The Laplace S/D potentials use chunkie's G = -log r/(2*pi) convention,
+% and grad denotes target gradient.
+%
+% Inputs:
+%   chnkr   - chunker (single connected sequence of panels).
+%   type    - 's' / 'single' (Stokes velocity SLP) or 'd' / 'double'.
+%   mu      - Stokes viscosity.
+%   dens    - 2 * chnkr.npt density samples (interleaved [s1 s2 s1 s2 ...]
+%             OR 2-by-npt grid).
+%   targets - 2 x nt real target locations.
+%   dlim    - (optional, default 1.1) close-target threshold.
+%   eval_opts - (optional) struct with .forcefmm passed to chunkerkerneval.
+%
+% Output:
+%   val     - 2 x nt array of Stokes velocity at each target.
+
+if nargin < 6 || isempty(dlim); dlim = 1.1; end
+if nargin < 7; eval_opts = []; end
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+npt = chnkr.npt;
+
+% normalize density to 2 x npt
+if size(dens, 1) == 2
+    sigma = dens;
+elseif numel(dens) == 2*npt
+    sigma = reshape(dens(:), 2, []);
+else
+    error('CHNK.KERNSPLIT.STO2D_PANEL_EVAL: dens must be 2-by-npt or length 2*npt');
+end
+
+% complex source / target data
+zsrc_all = chnkr.r(1,:,:) + 1i*chnkr.r(2,:,:); zsrc_all = zsrc_all(:).';  % 1 x npt
+nz_all   = chnkr.n(1,:,:) + 1i*chnkr.n(2,:,:); nz_all   = nz_all(:).';
+[~, wgl] = lege.exps(ngl);
+awzp_all = chnkr.wts(:).';
+d_all    = chnkr.d(1,:,:) + 1i*chnkr.d(2,:,:); d_all    = d_all(:).';
+wgl_rep  = repmat(wgl(:).', 1, nch);
+wzp_all  = d_all .* wgl_rep;
+y_all    = chnkr.r(:,:);                             % 2 x npt (real)
+
+if isstruct(targets)
+    targ_r = targets.r;
+    if isfield(targets,'n'), targ_n = targets.n; else, targ_n = []; end
+else
+    targ_r = targets;
+    targ_n = [];
+end
+ztgt = targ_r(1,:).' + 1i*targ_r(2,:).';              % nt x 1
+nt   = size(targ_r, 2);
+val  = zeros(2, nt);
+if ~isempty(targ_n)
+    nzt_all = (targ_n(1,:) + 1i*targ_n(2,:)).';       % nt x 1
+else
+    nzt_all = [];
+end
+
+% Note: we do NOT use chunkie's direct K_stokes kernel for the smooth
+% far-field, because the decomposition (Cauchy + Laplace D gradients)
+% used for the close correction is only equal to K_stokes after
+% INTEGRATION (eq (31) of Wu et al.).  Per-source the two forms differ;
+% mixing them produces wrong values at near-singular targets.  Instead,
+% the smooth far-field below is built panel-by-panel using the same
+% decomposition form, with smooth GL replacing wLCHS for far panels.
+
+if ~strcmpi(type,'s') && ~strcmpi(type,'single') && ...
+   ~strcmpi(type,'d') && ~strcmpi(type,'double') && ...
+   ~strcmpi(type,'strac') && ~strcmpi(type,'straction')
+    error('CHNK.KERNSPLIT.STO2D_PANEL_EVAL: unknown type %s', type);
+end
+
+is_strac = strcmpi(type,'strac') || strcmpi(type,'straction');
+if is_strac && isempty(nzt_all)
+    error(['CHNK.KERNSPLIT.STO2D_PANEL_EVAL: ''strac'' requires target ' ...
+           'normals; pass targets as struct with .r and .n']);
+end
+
+% --- per-panel evaluation, all panels (smooth + close correction in
+% the same decomposition form).
+[rends,~] = chunkends(chnkr);
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));
+panlen = zeros(nch,1);
+for ip = 1:nch
+    panlen(ip) = sum(awzp_all((ip-1)*ngl+(1:ngl)));
+end
+dlim2 = dlim^2;
+
+twopi = 2*pi;
+xt1 = targ_r(1,:).';
+xt2 = targ_r(2,:).';
+
+for ip = 1:nch
+    pidx = (ip-1)*ngl + (1:ngl);
+    zsrc_p = zsrc_all(pidx);
+    nz_p   = nz_all(pidx);
+    wzp_p  = wzp_all(pidx);
+    awzp_p = awzp_all(pidx);
+    y_p    = y_all(:, pidx);
+    s1_p   = sigma(1, pidx);
+    s2_p   = sigma(2, pidx);
+    a = endsa(ip); b = endsb(ip);
+
+    diff_p = ztgt - zsrc_p;
+    d2_p   = real(diff_p).*real(diff_p) + imag(diff_p).*imag(diff_p);
+    is_near = min(d2_p, [], 2) < dlim2*panlen(ip)^2;
+
+    % I_C and I_H smooth-GL per-source moments (nt x ngl) for THIS panel.
+    % Convention: I_C(tau) = integral tau(y)/(y-x) dy.  Smooth GL is
+    % sum_j wzp_j/(zsc_j - ztg_i) tau_j = sum_j wzp_j/(-diff_p) tau_j.
+    IC_smooth = -wzp_p ./ diff_p;        % nt x ngl  (note minus sign)
+    IH_smooth =  wzp_p ./ diff_p.^2;     % I_H = int tau/(y-x)^2 dy, even power
+
+    % For close targets, replace smooth with polynomial-evaluated value
+    if any(is_near)
+        ztgt_n = ztgt(is_near);
+        if strcmpi(type,'s') || strcmpi(type,'single')
+            U = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc_p);
+            [LogC, CauC] = chnk.kernsplit.wlchs_target(a, b, ztgt_n, ...
+                zsrc_p, nz_p, wzp_p, awzp_p, U, 0);
+        else
+            U = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc_p);
+            [LogC, CauC, HypC] = chnk.kernsplit.wlchs_target(a, b, ztgt_n, ...
+                zsrc_p, nz_p, wzp_p, awzp_p, U, 0);
+        end
+        % wcmpC = (poly - smooth)/1i for I_C per source.  So:
+        %    poly_per_source = i*wcmpC + smooth
+        %    delta = poly - smooth = i*wcmpC
+        % Add deltas onto the smooth values for near rows:
+        IC_smooth(is_near, :) = IC_smooth(is_near, :) + 1i*CauC;
+        if strcmpi(type,'d') || strcmpi(type,'double') || is_strac
+            % Same for I_H: poly = i*wcmpH + smooth, delta = i*wcmpH
+            IH_smooth(is_near, :) = IH_smooth(is_near, :) + 1i*HypC;
+        end
+        % Also need close-corrected I_L for SLP via Laplace S(tau): the
+        % decomposition for SLP needs S(s1), S(s2), S(y.sigma) and grad S
+        % of same.  S corrections use LogC; grad S uses I_C/(in_y).
+    end
+
+    % --- compute the decomposition contributions per target
+    ydots = y_p(1,:).*s1_p + y_p(2,:).*s2_p;     % 1 x ngl, (y.sigma)
+
+    switch lower(type)
+        case {'s','single'}
+            % S sigma = (1/(2*mu))[(S s1, S s2)
+            %                      + grad S(y.sigma) - x_1 grad S(s1) - x_2 grad S(s2)]
+            % S(tau) per-source moment (smooth or poly-corrected) is via
+            % Laplace SLP = -1/(2pi) I_L.  We use the same wlchs LogC
+            % moment as in lap2d (for far targets, the smooth_S_per_src is
+            % just -log(r)*awzp/(2pi); for close, add the LogC delta).
+            log_r_smooth = log(abs(diff_p));        % nt x ngl
+            % Laplace S smooth per source: -log(r)/(2pi)*awzp
+            S_per_src = -log_r_smooth .* awzp_p / twopi;
+            if any(is_near)
+                % Close correction adds -LogC*awzp/(2pi)
+                S_per_src(is_near, :) = S_per_src(is_near, :) + ...
+                    (-LogC .* awzp_p / twopi);
+            end
+            % grad S per source: x-component = (1/(2pi)) Re(I_C(tau/(in_y))_per_src)
+            % = (1/(2pi)) Re(IC_per_src/(i*nz_j)) when tau is the
+            % Lagrange basis at j.  But here tau is generic; per-source j
+            % the integrand contribution to I_C(tau/(in_y)) at row i is
+            % IC_smooth[i,j] / (i*nz_j) * tau_j.  So grad-S coefficient for
+            % source j of value tau_j is:
+            %   d/dx1 = (1/(2pi)) Re(IC_smooth[i,j] / (i*nz_j))
+            %   d/dx2 = -(1/(2pi)) Im(IC_smooth[i,j] / (i*nz_j))
+            G_per_src = IC_smooth ./ (1i * nz_p) / twopi;     % complex, nt x ngl
+            GxRe = real(G_per_src);
+            GxIm = -imag(G_per_src);
+
+            ux = (S_per_src * s1_p(:)) ...
+                + (GxRe * ydots(:)) ...
+                - xt1 .* (GxRe * s1_p(:)) ...
+                - xt2 .* (GxRe * s2_p(:));
+            uy = (S_per_src * s2_p(:)) ...
+                + (GxIm * ydots(:)) ...
+                - xt1 .* (GxIm * s1_p(:)) ...
+                - xt2 .* (GxIm * s2_p(:));
+            ux = ux / (2*mu);
+            uy = uy / (2*mu);
+
+        case {'d','double'}
+            % D sigma decomposition (Wu et al. eq 31, in chunkie's
+            % per-source "smooth GL" form).  First term:
+            %   (1/(2pi)) integral n_y/rho^2 (r.sigma) ds
+            % which is REAL.  In complex form using the I_C moment, this
+            % becomes (1/(2pi)) (-Im) of I_C applied to a complex tau.
+            % Paper (arXiv:1909.00049) eq 33 defines tau_k = (sigma_1
+            % + i sigma_2) * Re(n_y)/n_y for k=1 and Im for k=2; the
+            % paper writes "Re" but empirical verification shows the
+            % correct extraction is -Im (this is just a sign-convention
+            % difference, possibly a typo in the paper).
+            sigma_c = s1_p + 1i*s2_p;
+            tau1_p  = sigma_c .* (real(nz_p) ./ nz_p);
+            tau2_p  = sigma_c .* (imag(nz_p) ./ nz_p);
+            ICt1 = IC_smooth * tau1_p(:);
+            ICt2 = IC_smooth * tau2_p(:);
+
+            % grad D per source j:
+            %   d/dx1 D(tau) = -(1/(2pi)) Im(IH_per_src) tau_j
+            %   d/dx2 D(tau) = -(1/(2pi)) Re(IH_per_src) tau_j
+            IH_yS = IH_smooth * ydots(:);
+            IH_s1 = IH_smooth * s1_p(:);
+            IH_s2 = IH_smooth * s2_p(:);
+
+            ux = -imag(ICt1)/twopi ...
+                + (-imag(IH_yS)/twopi) ...
+                + xt1 .* (imag(IH_s1)/twopi) ...
+                + xt2 .* (imag(IH_s2)/twopi);
+            uy = -imag(ICt2)/twopi ...
+                + (-real(IH_yS)/twopi) ...
+                + xt1 .* (real(IH_s1)/twopi) ...
+                + xt2 .* (real(IH_s2)/twopi);
+
+        case {'strac','straction'}
+            % Stokes traction-of-SLP kernel K_strac = -(1/π) r_i r_j (r·n_t)/r⁴
+            % is the same shape as K_dvel = (1/π) r_i r_j (r·n_y)/r⁴ but with
+            % target normal n_t (constant per target) replacing source normal
+            % n_y, and overall sign flipped.  We obtain the K_strac
+            % Wu-Barnett decomposition by substituting in the 'd' code:
+            %   tau_k:  use Re(n_t(x))/n_y(y)  and  Im(n_t(x))/n_y(y)
+            %   IH[g]:  use g/n_y on source side, multiply by n_t(x) at target
+            % then negate the entire result.
+            sigma_c = s1_p + 1i*s2_p;
+            nzt_near = nzt_all(:);            % nt x 1, all targets
+            % sources factored by 1/n_y (chunkie tcau/thyp bake n_y in via
+            % awzp*n_y = -i*wzp, so dividing source-side density by n_y
+            % cancels that and lets us multiply by n_t at the target).
+            sigma_c_over_nz   = sigma_c ./ nz_p;
+            ydots_over_nz     = ydots ./ nz_p;
+            s1_over_nz        = s1_p ./ nz_p;
+            s2_over_nz        = s2_p ./ nz_p;
+
+            ICt0 = IC_smooth * sigma_c_over_nz(:);          % nt x 1 complex
+            ICt1 = real(nzt_near) .* ICt0;                  % τ_1_strac · IC
+            ICt2 = imag(nzt_near) .* ICt0;
+
+            IH_yS = nzt_near .* (IH_smooth * ydots_over_nz(:));
+            IH_s1 = nzt_near .* (IH_smooth * s1_over_nz(:));
+            IH_s2 = nzt_near .* (IH_smooth * s2_over_nz(:));
+
+            % K_strac = -K_dvel-with-n_t, so flip every sign of the 'd' result.
+            ux = +imag(ICt1)/twopi ...
+                + (+imag(IH_yS)/twopi) ...
+                - xt1 .* (imag(IH_s1)/twopi) ...
+                - xt2 .* (imag(IH_s2)/twopi);
+            uy = +imag(ICt2)/twopi ...
+                + (+real(IH_yS)/twopi) ...
+                - xt1 .* (real(IH_s1)/twopi) ...
+                - xt2 .* (real(IH_s2)/twopi);
+    end
+
+    val(1, :) = val(1, :) + ux.';
+    val(2, :) = val(2, :) + uy.';
+end
+end

--- a/chunkie/+chnk/+kernsplit/sto2d_self_correction.m
+++ b/chunkie/+chnk/+kernsplit/sto2d_self_correction.m
@@ -1,0 +1,86 @@
+function [delta, U_src_cell] = sto2d_self_correction(chnkr, type, mu, U_src_cell)
+%CHNK.KERNSPLIT.STO2D_SELF_CORRECTION  self-panel close correction for the
+% 2D Stokes velocity layer-potential kernels, decomposed by sub-block.
+%
+% Velocity SLP (chunkie convention):
+%   K_xx_svel = (1/(4*pi*mu)) (rx^2/r^2 + log(1/r))
+%   K_yy_svel = (1/(4*pi*mu)) (ry^2/r^2 + log(1/r))
+%   K_xy_svel = K_yx_svel = (1/(4*pi*mu)) rx*ry/r^2
+% i.e. a bounded smooth piece (r_i r_j / r^2) plus a Laplace-SLP-times-
+% delta_ij log piece.  The log piece equals (1/(2*mu)) times the chunkie
+% Laplace SLP kernel; we reuse chnk.kernsplit.lap2d_self_correction for
+% that.  The bounded piece needs only the analytic diagonal limit
+% tau_i tau_j to finite-fix the smooth-GL diagonal entry.
+%
+% Velocity DLP (chunkie convention):
+%   K_ij_dvel = (1/pi) r_i r_j (n_s . r) / r^4
+% bounded everywhere on a smooth closed boundary, with diagonal limit
+% kappa tau_i tau_j / (2*pi).  No log; smooth GL on off-diagonals is
+% already exponentially accurate at panel order 16, so only the analytic
+% diagonal limit is needed.
+%
+% Inputs:
+%   chnkr       - chunker
+%   type        - SLP: 'svel_xx', 'svel_xy', 'svel_yx', 'svel_yy'
+%                 DLP: 'dvel_xx', 'dvel_xy', 'dvel_yx', 'dvel_yy'
+%   mu          - viscosity (used by SLP only; DLP is mu-independent)
+%   U_src_cell  - cached per-panel inverse Vandermonde from prior calls
+%
+% Output: sparse npt x npt delta matrix following the chunkermat
+%   forcewlchs convention --
+%     diagonal entries  = FULL close-eval matrix entry (M_smooth diag is
+%                         zeroed by the caller, so this *replaces* it),
+%     off-diagonal      = (close - smooth) of the matrix entry,
+% so that  M_smooth + delta  = full close-eval block matrix.
+
+if nargin < 4 || isempty(U_src_cell)
+    U_src_cell = cell(1, chnkr.nch);
+end
+N   = chnkr.npt;
+d   = chnkr.d(:,:);
+d2  = chnkr.d2(:,:);
+w   = chnkr.wts(:);
+spd = sqrt(d(1,:).^2 + d(2,:).^2).';
+tx  = d(1,:).' ./ spd;
+ty  = d(2,:).' ./ spd;
+kappa = ((d(1,:).*d2(2,:) - d(2,:).*d2(1,:)).' ./ spd.^3);
+
+switch lower(type)
+    case 'svel_xx'
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction( ...
+            chnkr, 's', U_src_cell);
+        bounded_diag = (1/(4*pi*mu)) * tx.^2 .* w;
+        delta = (1/(2*mu)) * lap_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case 'svel_yy'
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction( ...
+            chnkr, 's', U_src_cell);
+        bounded_diag = (1/(4*pi*mu)) * ty.^2 .* w;
+        delta = (1/(2*mu)) * lap_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case {'svel_xy', 'svel_yx'}
+        bounded_diag = (1/(4*pi*mu)) * tx.*ty .* w;
+        delta = sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case {'dvel_xx', 'strac_xx'}
+        % Stokes DLP / traction-of-SLP on a smooth boundary are bounded
+        % everywhere with the same diagonal limit -kappa tau_i tau_j /(2*pi).
+        %   K_ij_dvel  = +(1/pi) r_i r_j (n_s . r) / r^4   (source normal)
+        %   K_ij_strac = -(1/pi) r_i r_j (n_t . r) / r^4   (target normal)
+        % Using chunkie's curvature convention dn/ds = +kappa tau, both
+        % limits land at  -kappa tau_i tau_j / (2*pi) * w.
+        diag_v = -(1/(2*pi)) * kappa .* tx.^2 .* w;
+        delta = sparse(1:N, 1:N, diag_v, N, N);
+
+    case {'dvel_yy', 'strac_yy'}
+        diag_v = -(1/(2*pi)) * kappa .* ty.^2 .* w;
+        delta = sparse(1:N, 1:N, diag_v, N, N);
+
+    case {'dvel_xy', 'dvel_yx', 'strac_xy', 'strac_yx'}
+        diag_v = -(1/(2*pi)) * kappa .* tx .* ty .* w;
+        delta = sparse(1:N, 1:N, diag_v, N, N);
+
+    otherwise
+        error('CHNK.KERNSPLIT.STO2D_SELF_CORRECTION: type %s not supported', type);
+end
+end

--- a/chunkie/chunkermat.m
+++ b/chunkie/chunkermat.m
@@ -854,9 +854,36 @@ if islogical(fw) || (isnumeric(fw) && isscalar(fw))
     end
     fam = wlchs_kernel_family(kern);
     if isempty(fam)
-        error("chunkermat: opts.forcewlchs=true requires a single helm2d or lap2d kernel");
+        error("chunkermat: opts.forcewlchs=true requires a single helm2d, lap2d, or stok2d kernel");
     end
     t = lower(kern.type);
+    if strcmp(fam, 'stokes')
+        % Stokes velocity SLP/DLP is a 2x2 opdims kernel; populate the 4
+        % sub-block layout cells.  Supported: 'svel' (single layer),
+        % 'dvel' (double layer), 'strac' (traction).
+        if ismember(t, {'s','single','svel','svelocity'})
+            stok_kind = 'svel';
+        elseif ismember(t, {'d','double','dvel','dvelocity'})
+            stok_kind = 'dvel';
+        elseif ismember(t, {'strac','straction'})
+            stok_kind = 'strac';
+        else
+            error("chunkermat: opts.forcewlchs=true: stok kernel type %s not supported", kern.type);
+        end
+        if m ~= 2 || n ~= 2
+            error("chunkermat: opts.forcewlchs=true on stok '%s' requires opdims=[2 2]", stok_kind);
+        end
+        if ~isfield(kern.params, 'mu') || isempty(kern.params.mu)
+            error("chunkermat: opts.forcewlchs (stokes) requires kern.params.mu");
+        end
+        mu = kern.params.mu;
+        coef = wlchs_extract_scalar(kern, stok_kind, mu, 'stokes');
+        layout{1,1} = struct('type',[stok_kind '_xx'],'coef',coef,'mu',mu,'family','stokes');
+        layout{1,2} = struct('type',[stok_kind '_xy'],'coef',coef,'mu',mu,'family','stokes');
+        layout{2,1} = struct('type',[stok_kind '_yx'],'coef',coef,'mu',mu,'family','stokes');
+        layout{2,2} = struct('type',[stok_kind '_yy'],'coef',coef,'mu',mu,'family','stokes');
+        return_after = false;  %#ok<NASGU>
+    else
     if m ~= 1 || n ~= 1
         error("chunkermat: opts.forcewlchs=true requires a single scalar (opdims=[1 1]) helm or lap kernel");
     end
@@ -888,20 +915,23 @@ if islogical(fw) || (isnumeric(fw) && isscalar(fw))
         coef = wlchs_extract_scalar(kern, t, zk, fam);
         layout{1,1} = struct('type', t, 'coef', coef, 'zk', zk, 'family', fam);
     end
+    end  % end of stokes / non-stokes branch
 elseif isstruct(fw)
     if ~isfield(fw, 'layout')
         error("chunkermat: opts.forcewlchs struct needs field 'layout'");
     end
-    % Top-level defaults; per-entry struct can override family / zk.
+    % Top-level defaults; per-entry struct can override family / zk / mu.
     fam_default = 'helmholtz';
     if isfield(fw, 'family') && ~isempty(fw.family)
         fam_default = lower(fw.family);
     end
-    if ~ismember(fam_default, {'helmholtz','laplace'})
-        error("chunkermat: opts.forcewlchs.family must be 'helmholtz' or 'laplace'");
+    if ~ismember(fam_default, {'helmholtz','laplace','stokes'})
+        error("chunkermat: opts.forcewlchs.family must be 'helmholtz', 'laplace', or 'stokes'");
     end
     zk_default = [];
+    mu_default = [];
     if isfield(fw, 'zk') && ~isempty(fw.zk), zk_default = fw.zk; end
+    if isfield(fw, 'mu') && ~isempty(fw.mu), mu_default = fw.mu; end
 
     L = fw.layout;
     if ~iscell(L) || size(L,1) ~= m || size(L,2) ~= n
@@ -913,6 +943,7 @@ elseif isstruct(fw)
             if isempty(entry); continue; end
             ent_fam = fam_default;
             ent_zk  = zk_default;
+            ent_mu  = mu_default;
             if iscell(entry)
                 t = entry{1}; a = entry{2};
             elseif isstruct(entry)
@@ -926,6 +957,7 @@ elseif isstruct(fw)
                     ent_fam = lower(entry.family);
                 end
                 if isfield(entry, 'zk') && ~isempty(entry.zk), ent_zk = entry.zk; end
+                if isfield(entry, 'mu') && ~isempty(entry.mu), ent_mu = entry.mu; end
             else
                 error("chunkermat: opts.forcewlchs.layout{%d,%d} bad form", r, c);
             end
@@ -940,6 +972,13 @@ elseif isstruct(fw)
                     end
                 case 'laplace'
                     allowed_e = lap_types;
+                case 'stokes'
+                    allowed_e = {'svel_xx','svel_xy','svel_yx','svel_yy', ...
+                                 'dvel_xx','dvel_xy','dvel_yx','dvel_yy', ...
+                                 'strac_xx','strac_xy','strac_yx','strac_yy'};
+                    if isempty(ent_mu)
+                        error("chunkermat: forcewlchs stokes layout entry (%d,%d) needs mu", r, c);
+                    end
                 otherwise
                     error("chunkermat: unknown family %s", ent_fam);
             end
@@ -952,16 +991,16 @@ elseif isstruct(fw)
                     error("chunkermat: forcewlchs c layout entry needs coefs [c1, c2]");
                 end
                 layout{r,c} = struct('type', 'c', 'coefs', a(:).', ...
-                                     'zk', ent_zk, 'family', ent_fam);
+                                     'zk', ent_zk, 'mu', ent_mu, 'family', ent_fam);
             elseif strcmpi(t, 'sc') || strcmpi(t, 'spcombined')
                 if ~isvector(a) || numel(a) ~= 2
                     error("chunkermat: forcewlchs sc layout entry needs coefs [c1, c2]");
                 end
                 layout{r,c} = struct('type', 'sc', 'coefs', a(:).', ...
-                                     'zk', ent_zk, 'family', ent_fam);
+                                     'zk', ent_zk, 'mu', ent_mu, 'family', ent_fam);
             else
                 layout{r,c} = struct('type', lower(t), 'coef', a, ...
-                                     'zk', ent_zk, 'family', ent_fam);
+                                     'zk', ent_zk, 'mu', ent_mu, 'family', ent_fam);
             end
         end
     end
@@ -1123,13 +1162,14 @@ end
 end
 
 function fam = wlchs_kernel_family(kern)
-% Returns 'helmholtz', 'laplace', or '' if the kernel is unsupported by
-% the wLCHS path.
+% Returns 'helmholtz', 'laplace', 'stokes', or '' if the kernel is
+% unsupported by the wLCHS path.
 fam = '';
 if ~isa(kern, 'kernel'), return; end
 if strcmpi(kern.name, 'zeros'), return; end
 if strcmpi(kern.name, 'helmholtz'), fam = 'helmholtz'; return; end
 if strcmpi(kern.name, 'laplace'),   fam = 'laplace';   return; end
+if strcmpi(kern.name, 'stokes'),    fam = 'stokes';    return; end
 end
 
 function tf = wlchs_has_self_correction(type, family)
@@ -1138,6 +1178,9 @@ function tf = wlchs_has_self_correction(type, family)
 % points). For combined 'c' = c1*D + c2*S we return true and let the
 % application step multiply c2 (zero if S is absent); same idea for 'sc'.
 % Laplace: S, D, S', D' all have nontrivial self corrections.
+% Stokes: each velocity-SLP sub-block has a non-trivial self correction
+% (analytic diagonal limit on all four sub-blocks; log close-eval on the
+% (xx, yy) diagonal sub-blocks).
 if nargin < 2 || isempty(family), family = 'helmholtz'; end
 switch lower(family)
     case 'helmholtz'
@@ -1145,6 +1188,10 @@ switch lower(family)
                                     'c','combined','sc','spcombined'});
     case 'laplace'
         tf = ismember(lower(type), {'s','single','d','double','sp','sprime','dp','dprime'});
+    case 'stokes'
+        tf = ismember(lower(type), {'svel_xx','svel_xy','svel_yx','svel_yy', ...
+                                     'dvel_xx','dvel_xy','dvel_yx','dvel_yy', ...
+                                     'strac_xx','strac_xy','strac_yx','strac_yy'});
     otherwise
         tf = false;
 end
@@ -1159,6 +1206,8 @@ switch lower(spec.family)
         [delta, U_src_cell] = chnk.kernsplit.helm2d_self_correction(chnkr, type, spec.zk, U_src_cell);
     case 'laplace'
         [delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction(chnkr, type, U_src_cell);
+    case 'stokes'
+        [delta, U_src_cell] = chnk.kernsplit.sto2d_self_correction(chnkr, type, spec.mu, U_src_cell);
     otherwise
         error('wlchs_self_correction_dispatch: unsupported family %s', spec.family);
 end
@@ -1170,6 +1219,8 @@ switch lower(spec.family)
         [delta, U_src_cell] = chnk.kernsplit.helm2d_adj_correction(chnkr, type, spec.zk, U_src_cell);
     case 'laplace'
         [delta, U_src_cell] = chnk.kernsplit.lap2d_adj_correction(chnkr, type, U_src_cell);
+    case 'stokes'
+        [delta, U_src_cell] = chnk.kernsplit.sto2d_adj_correction(chnkr, type, spec.mu, U_src_cell);
     otherwise
         error('wlchs_adj_correction_dispatch: unsupported family %s', spec.family);
 end
@@ -1210,6 +1261,26 @@ switch lower(spec.family)
             otherwise
                 error('wlchs_kernel_eval: lap type %s not supported', type);
         end
+    case 'stokes'
+        tlow = lower(type);
+        if startsWith(tlow, 'svel_')
+            K_full = chnk.stok2d.kern(spec.mu, si, ti, 'svel');
+        elseif startsWith(tlow, 'dvel_')
+            K_full = chnk.stok2d.kern(spec.mu, si, ti, 'dvel');
+        elseif startsWith(tlow, 'strac_')
+            K_full = chnk.stok2d.kern(spec.mu, si, ti, 'strac');
+        else
+            error('wlchs_kernel_eval: stokes type %s not supported', type);
+        end
+        sub = tlow(end-1:end);
+        switch sub
+            case 'xx', K = K_full(1:2:end, 1:2:end);
+            case 'xy', K = K_full(1:2:end, 2:2:end);
+            case 'yx', K = K_full(2:2:end, 1:2:end);
+            case 'yy', K = K_full(2:2:end, 2:2:end);
+            otherwise
+                error('wlchs_kernel_eval: stokes sub-block %s not supported', sub);
+        end
     otherwise
         error('wlchs_kernel_eval: unsupported family %s', spec.family);
 end
@@ -1224,7 +1295,7 @@ function coef = wlchs_extract_scalar(kern, t, param, family)
 %
 % `param` carries family-specific data (zk for helmholtz, [] for laplace).
 if nargin < 4 || isempty(family), family = 'helmholtz'; end
-if strcmp(family, 'laplace')
+if strcmp(family, 'laplace') || strcmp(family, 'stokes')
     src_probe = struct('r',[0;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
     tgt_probe = struct('r',[2;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
 else
@@ -1258,6 +1329,21 @@ switch lower(family)
                 error('wlchs_extract_scalar: lap type %s not supported', t);
         end
         coef = val / base;
+    case 'stokes'
+        % Stokes svel/dvel return 2x2 matrices; ratio on a non-zero entry
+        % gives the scalar prefactor (assumes the user's kern is a scalar
+        % multiple of the bare Stokes kernel of type t).
+        mu = param;
+        if ismember(lower(t), {'s','single','svel','svelocity'})
+            base = chnk.stok2d.kern(mu, src_probe, tgt_probe, 'svel');
+        elseif ismember(lower(t), {'d','double','dvel','dvelocity'})
+            base = chnk.stok2d.kern(mu, src_probe, tgt_probe, 'dvel');
+        elseif ismember(lower(t), {'strac','straction'})
+            base = chnk.stok2d.kern(mu, src_probe, tgt_probe, 'strac');
+        else
+            error('wlchs_extract_scalar: stok type %s not supported', t);
+        end
+        coef = val(1,1) / base(1,1);
     otherwise
         error('wlchs_extract_scalar: unsupported family %s', family);
 end

--- a/devtools/test/chunkermat_stok_forcewlchsTest.m
+++ b/devtools/test/chunkermat_stok_forcewlchsTest.m
@@ -1,0 +1,72 @@
+function chunkermat_stok_forcewlchsTest()
+%CHUNKERMAT_STOK_FORCEWLCHSTEST  Verify chunkermat opts.forcewlchs
+%   dispatches to chnk.kernsplit Stokes self/adj corrections for both
+%   the Stokes velocity SLP and DLP kernels.
+%
+%   Test: builds the forcewlchs Stokes matrices and compares operator
+%   action against chunkermat's default scheme on a smooth density
+%   (avoiding the radial-normal direction which is effectively in the
+%   Stokes SLP null space on a unit circle).
+
+cparams = []; cparams.ta = 0; cparams.tb = 2*pi; cparams.ifclosed = true;
+cparams.maxchunklen = 2*pi/8;
+pref = []; pref.k = 16;
+chnkr = chunkerfunc(@(t) circle_param(t), cparams, pref);
+mu = 1.7;
+
+N = chnkr.npt;
+r  = chnkr.r(:,:);
+ang = atan2(r(2,:), r(1,:)).';
+sig = zeros(2*N, 1);
+sig(1:2:end) = cos(2*ang);
+sig(2:2:end) = sin(2*ang);
+
+% --- SLP (svel) ---
+S_def = chunkermat(chnkr, kernel('stok','svel',mu));
+S_wl  = chunkermat(chnkr, kernel('stok','svel',mu), ...
+                   struct('quad','native','forcewlchs',true));
+err = norm(S_def*sig - S_wl*sig) / norm(S_def*sig);
+fro_err = norm(S_def - S_wl, 'fro') / norm(S_def, 'fro');
+fprintf('  svel: action %.3e (rel),  Frob %.3e (rel)\n', err, fro_err);
+assert(err < 1e-9);
+assert(fro_err < 1e-9);
+
+% --- DLP (dvel): bounded kernel; default already smooth-GL.  forcewlchs
+%     reproduces it via analytic diagonal limit. ---
+D_def = chunkermat(chnkr, kernel('stok','dvel',mu));
+D_wl  = chunkermat(chnkr, kernel('stok','dvel',mu), ...
+                   struct('quad','native','forcewlchs',true));
+% Use a non-null-space density: constant (1,0).  The Stokes DLP interior
+% trace identity gives D*sigma_const = -sigma_const/2.
+sig_const = zeros(2*N,1); sig_const(1:2:end) = 1;
+errD = norm(D_def*sig_const - D_wl*sig_const) / norm(D_def*sig_const);
+fro_errD = norm(D_def - D_wl, 'fro') / norm(D_def, 'fro');
+fprintf('  dvel: action %.3e (rel),  Frob %.3e (rel)\n', errD, fro_errD);
+assert(errD < 1e-9);
+assert(fro_errD < 1e-9);
+
+% --- D*1 = -1/2 identity (interior trace of Stokes DLP). ---
+sig1 = ones(2*N, 1);
+val_D1 = D_wl * sig1;
+err_id = norm(val_D1 + 0.5*sig1, 'inf');
+fprintf('  dvel: ||D*1 + 1/2||_inf = %.3e\n', err_id);
+assert(err_id < 1e-12);
+
+% --- Boolean form on a scalar-multiplied Stokes svel ---
+kern_scaled = 2.5 * kernel('stok','svel',mu);
+S_scaled_def = chunkermat(chnkr, kern_scaled);
+S_scaled_wl  = chunkermat(chnkr, kern_scaled, ...
+                          struct('quad','native','forcewlchs',true));
+err2 = norm(S_scaled_def * sig - S_scaled_wl * sig) / norm(S_scaled_def * sig);
+fprintf('  2.5*svel scaled match: %.3e (rel)\n', err2);
+assert(err2 < 1e-9);
+
+fprintf('PASS: chunkermat forcewlchs stok dispatch works for svel and dvel\n');
+end
+
+function [r, d, d2] = circle_param(t)
+ct = cos(t); st = sin(t);
+r  = [ct(:).';  st(:).'];
+d  = [-st(:).'; ct(:).'];
+d2 = [-ct(:).'; -st(:).'];
+end


### PR DESCRIPTION
## Summary
Builds on #172 (Laplace) and #174 (Helmholtz) and adds Stokes velocity layer-potential support to the `chunkermat` forcewlchs framework. Stokes velocity kernels are 2x2 in opdims; each `(xx, xy, yx, yy)` sub-block gets an independent kernsplit self/adjacent correction.

## What's included
- **New `chnk.kernsplit` Stokes routines**: `sto2d_self_correction`, `sto2d_adj_correction`, `sto2d_panel_eval`. Each dispatches on the sub-block type (`svel_xx`, ..., `dvel_xx`, ..., `strac_xx`, ...).
- **`chunkermat` (`forcewlchs`)**:
  - `wlchs_kernel_family`, `wlchs_has_self_correction`, `wlchs_*_dispatch`, `wlchs_kernel_eval`, `wlchs_extract_scalar` extended with Stokes cases (`mu` passed through `spec.mu`).
  - **Boolean form**: a 2x2 `stok2d` kernel (type `s`/`svel`, `d`/`dvel`, `strac`) auto-populates the 4 sub-block layout cells.
  - **Struct form**: `fw.mu` may be specified at top level, or per layout entry.

## Test plan
- [x] `devtools/test/chunkermat_stok_forcewlchsTest.m` (new) — verifies `forcewlchs` Stokes svel and dvel agree with default GGQ at ~1e-9 (operator action) on a unit-circle problem, plus the `D*1 = -1/2` interior-trace identity to 1e-12.
- [x] Laplace and Helmholtz regressions (`chunkermat_lap_forcewlchsTest`, `chunkermat_helm_forcewlchsTest`) still pass.

## Notes
- Stacked on #174. PR 1c of 6.
- Original implementation contributed by @sj90101.
