### PR TITLE
Extend kernel-split forcewlchs to 2D elasticity (Kelvin)

### DIFF
--- a/chunkie/+chnk/+kernsplit/elast2d_adj_correction.m
+++ b/chunkie/+chnk/+kernsplit/elast2d_adj_correction.m
@@ -1,0 +1,160 @@
+function [delta, U_src_cell] = elast2d_adj_correction(chnkr, type, lam, mu, U_src_cell)
+%CHNK.KERNSPLIT.ELAST2D_ADJ_CORRECTION  adjacent-panel close correction
+% delta for 2D linear elasticity layer potentials, decomposed by
+% sub-block.  See ELAST2D_SELF_CORRECTION for the convention.
+%
+% Only sub-blocks with a true singular piece (log or Cauchy) need adj
+% corrections; bounded pieces are resolved exponentially by smooth GL on
+% panel-order-16 adjacent panels and contribute no adj delta.
+
+if nargin < 5 || isempty(U_src_cell)
+    U_src_cell = cell(1, chnkr.nch);
+end
+
+N = chnkr.npt;
+
+% material coefficients
+beta = (lam + 3*mu) / (4*pi*mu*(lam + 2*mu));
+eta  = mu / (2*pi*(lam + 2*mu));
+
+tlow = lower(type);
+
+switch tlow
+    case {'s_xx', 's_yy'}
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_adj_correction( ...
+            chnkr, 's', U_src_cell);
+        delta = (-2*pi*beta) * lap_delta;
+
+    case {'s_xy', 's_yx'}
+        delta = sparse(N, N);
+
+    case 'd_xx'
+        % -eta*(r.n_y)/r^2 piece needs Lap D adj correction; bounded zeta
+        % piece resolved by smooth GL.
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_adj_correction( ...
+            chnkr, 'd', U_src_cell);
+        delta = (-2*pi*eta) * lap_delta;
+
+    case 'd_yy'
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_adj_correction( ...
+            chnkr, 'd', U_src_cell);
+        delta = (-2*pi*eta) * lap_delta;
+
+    case 'd_xy'
+        [Cau_adj, U_src_cell] = elast2d_cauchy_adj_block( ...
+            chnkr, 'src_im', U_src_cell);
+        delta = (+eta) * Cau_adj;
+
+    case 'd_yx'
+        [Cau_adj, U_src_cell] = elast2d_cauchy_adj_block( ...
+            chnkr, 'src_im', U_src_cell);
+        delta = (-eta) * Cau_adj;
+
+    case 'strac_xx'
+        % eta*(r.n_t)/r^2 piece via Lap S' adj correction.
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_adj_correction( ...
+            chnkr, 'sp', U_src_cell);
+        delta = (-2*pi*eta) * lap_delta;
+
+    case 'strac_yy'
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_adj_correction( ...
+            chnkr, 'sp', U_src_cell);
+        delta = (-2*pi*eta) * lap_delta;
+
+    case 'strac_xy'
+        [Cau_adj, U_src_cell] = elast2d_cauchy_adj_block( ...
+            chnkr, 'tgt_im', U_src_cell);
+        delta = (+eta) * Cau_adj;
+
+    case 'strac_yx'
+        [Cau_adj, U_src_cell] = elast2d_cauchy_adj_block( ...
+            chnkr, 'tgt_im', U_src_cell);
+        delta = (-eta) * Cau_adj;
+
+    case {'dalt_xx', 'dalt_yy', 'dalt_xy', 'dalt_yx'}
+        delta = sparse(N, N);
+
+    otherwise
+        error('CHNK.KERNSPLIT.ELAST2D_ADJ_CORRECTION: type %s not supported', type);
+end
+
+end
+
+
+function [Cau, U_src_cell] = elast2d_cauchy_adj_block(chnkr, mode, U_src_cell)
+% Adjacent-panel close-correction for elasticity Cauchy pieces.
+%   mode = 'src_im' :  delta = Im(CauC)
+%   mode = 'tgt_im' :  delta = Im(nzt .* CauC ./ nz)
+%
+% Mirrors LAP2D_ADJ_CORRECTION's source/target loop and per-panel-pair
+% geometry setup, but extracts Im rather than -Re of CauC (and, for
+% target-normal, multiplies by nzt/nz before taking Im).
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+N   = chnkr.npt;
+
+[T_GL, wgl, U_GL_panel] = lege.exps(ngl);
+P_left  = (-1).^(0:ngl-1);
+P_right = ones(1, ngl);
+
+[rends, ~] = chunkends(chnkr);
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));
+
+speed_left  = zeros(nch, 1);
+speed_right = zeros(nch, 1);
+for ip = 1:nch
+    di = chnkr.d(:, :, ip);
+    cdi = U_GL_panel * (di.');
+    dleft  = P_left  * cdi;
+    dright = P_right * cdi;
+    speed_left(ip)  = norm(dleft);
+    speed_right(ip) = norm(dright);
+end
+
+ii = []; jj = []; vv = [];
+
+for ip_src = 1:nch
+    src_idx = (ip_src-1)*ngl + (1:ngl);
+    zsrc = chnkr.r(1,:,ip_src) + 1i*chnkr.r(2,:,ip_src);
+    nz_s = chnkr.n(1,:,ip_src) + 1i*chnkr.n(2,:,ip_src);
+    d_s  = chnkr.d(1,:,ip_src) + 1i*chnkr.d(2,:,ip_src);
+    wzp  = d_s .* wgl(:).';
+    awzp = chnkr.wts(:, ip_src).';
+    a = endsa(ip_src);
+    b = endsb(ip_src);
+
+    if isempty(U_src_cell{ip_src})
+        U_src_cell{ip_src} = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc);
+    end
+    U_src = U_src_cell{ip_src};
+
+    for side = [1, 2]
+        ip_tgt = chnkr.adj(side, ip_src);
+        if ip_tgt <= 0; continue; end
+
+        tgt_idx = (ip_tgt-1)*ngl + (1:ngl);
+        ztgt = (chnkr.r(1,:,ip_tgt) + 1i*chnkr.r(2,:,ip_tgt)).';
+        nzt  = (chnkr.n(1,:,ip_tgt) + 1i*chnkr.n(2,:,ip_tgt)).';
+
+        [~, CauC] = chnk.kernsplit.wlchs_target(a, b, ztgt, zsrc, nz_s, ...
+            wzp, awzp, U_src, 0);
+
+        switch mode
+            case 'src_im'
+                Mblk = -imag(CauC);
+            case 'tgt_im'
+                Mblk = -imag(nzt .* (CauC ./ nz_s));
+            otherwise
+                error('elast2d_cauchy_adj_block: unknown mode %s', mode);
+        end
+
+        [I, J] = ndgrid(tgt_idx, src_idx);
+        ii = [ii; I(:)];
+        jj = [jj; J(:)];
+        vv = [vv; Mblk(:)];
+    end
+end
+Cau = sparse(ii, jj, vv, N, N);
+end

--- a/chunkie/+chnk/+kernsplit/elast2d_panel_eval.m
+++ b/chunkie/+chnk/+kernsplit/elast2d_panel_eval.m
@@ -1,0 +1,271 @@
+function val = elast2d_panel_eval(chnkr, type, lam, mu, dens, targets, dlim, eval_opts)
+%CHNK.KERNSPLIT.ELAST2D_PANEL_EVAL  off-curve evaluation of 2D linear
+% elasticity layer potentials with Wu-Barnett-style kernel-split close
+% correction.
+%
+% Decomposes each elasticity sub-block into a sum of Laplace S/D/S' pieces
+% (component-wise) and Stokes svel/dvel pieces (vector-valued), each of
+% which is evaluated with its own wLCHS panel-eval that handles both smooth
+% far-field and polynomial-exact close correction.  Hence accuracy reaches
+% near machine precision down to target-to-curve distances much smaller
+% than the panel length, matching the Stokes-mobility precedent.
+%
+% Decompositions (chnk.elast2d.kern conventions, Lap_S = -log|r|/(2pi),
+% Lap_D = (r.n_y)/(2pi r^2), Lap_Sp = -(r.n_t)/(2pi r^2),
+% K_svel_ij = (r_i r_j/r^2 + log(1/|r|) δ_ij)/(4pi mu),
+% K_dvel_ij = r_i r_j (r.n_y)/(pi r^4)):
+%
+%   S_ij σ_j  = α_S * Lap_S(σ_i) - π ζ * (K_svel σ)_i + (γ/2) * Σ_i
+%               where α_S = -1/(λ+2μ),  Σ_i = integral of σ_i over Γ
+%
+%   D_ij σ_j  = -2π η * Lap_D(σ_i) - π ζ * (K_dvel σ)_i
+%               + η * ∫(r×n_y)/r² σ_j ds * ε_ij  (sum over j, ε_12=+1, ε_21=-1)
+%
+%   Dalt_ij σ_j = -4π η * Lap_D(σ_i) - π ζ * (K_dvel σ)_i
+%
+%   Strac_ij σ_j = -2π η * Lap_Sp(σ_i) (target-normal)
+%                  - η * ∫(r×n_t)/r² σ_j ds * ε_ij  (sum over j, ε_12=+1, ε_21=-1)
+%                  + ζ * ∫ r_i r_j (r.n_t)/r^4 σ_j ds  (no Wu-Barnett yet)
+%
+% Strac is not yet fully Wu-Barnett because chunkie does not provide a
+% Stokes-traction wLCHS panel-eval; its ζ piece uses smooth GL and so
+% degrades for very-close targets.  S, D, and Dalt are fully Wu-Barnett.
+%
+% Inputs:
+%   chnkr     - chunker (closed boundary or single connected arc)
+%   type      - 's' / 'single', 'd' / 'double', 'strac' / 'straction',
+%               'dalt'
+%   lam, mu   - Lame parameters
+%   dens      - 2 x chnkr.npt or length-2*chnkr.npt vector
+%   targets   - 2 x nt real point matrix, or struct with fields .r (2 x nt)
+%               and .n (2 x nt) target normals (required for 'strac')
+%   dlim      - (optional, default 1.1) close-target panel-length threshold
+%   eval_opts - (optional) struct, .forcefmm forwards to chunkerkerneval
+
+if nargin < 7 || isempty(dlim); dlim = 1.1; end
+if nargin < 8; eval_opts = []; end
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+npt = chnkr.npt;
+
+% Normalize target spec
+if isstruct(targets)
+    targ_r = targets.r;
+    if isfield(targets,'n'), targ_n = targets.n; else, targ_n = []; end
+else
+    targ_r = targets;
+    targ_n = [];
+end
+nt = size(targ_r, 2);
+
+% Normalize density to 2 x npt
+if isnumeric(dens) && size(dens,1) == 2
+    sigma = dens;
+elseif numel(dens) == 2*npt
+    sigma = reshape(dens(:), 2, []);
+else
+    error('CHNK.KERNSPLIT.ELAST2D_PANEL_EVAL: dens must be 2-by-npt or length 2*npt');
+end
+
+tlow = lower(type);
+
+% Material coefficients
+beta  = (lam + 3*mu) / (4*pi*mu*(lam + 2*mu));
+gamma = -(lam + mu) / (4*pi*mu*(lam + 2*mu));
+eta   = mu / (2*pi*(lam + 2*mu));
+zeta  = (lam + mu) / (pi*(lam + 2*mu));
+alpha_S = -2*pi*(beta + gamma);            % = -1/(λ+2μ)
+alpha_Ksvel = -pi*zeta;                    % = 4πμγ
+alpha_D   = -2*pi*eta;                     % coefficient on Lap_D for D xx,yy
+alpha_Dalt = -4*pi*eta;                    % coefficient on Lap_D for Dalt
+alpha_Sp   = -2*pi*eta;                    % coefficient on Lap_Sp for Strac
+alpha_Kdvel = -pi*zeta;                    % coefficient on K_dvel for D, Dalt
+
+val = zeros(2, nt);
+
+switch tlow
+    % ============================ S =============================
+    case {'s','single'}
+        % Lap_S piece (per component)
+        for k = 1:2
+            uk = chnk.kernsplit.lap2d_panel_eval(chnkr, 's', ...
+                sigma(k,:).', targ_r, dlim, eval_opts);
+            val(k,:) = val(k,:) + alpha_S * uk(:).';
+        end
+        % Stokes svel piece (vector-valued)
+        usv = chnk.kernsplit.sto2d_panel_eval(chnkr, 's', mu, sigma, ...
+            targ_r, dlim, eval_opts);
+        val = val + alpha_Ksvel * usv;
+        % γ/2 * Σ constant piece
+        awzp_all = chnkr.wts(:).';
+        Sig = sigma .* awzp_all;
+        Sig_total = sum(Sig, 2);
+        val(1,:) = val(1,:) + (gamma/2) * Sig_total(1);
+        val(2,:) = val(2,:) + (gamma/2) * Sig_total(2);
+
+    % ============================ D =============================
+    case {'d','double'}
+        for k = 1:2
+            uk = chnk.kernsplit.lap2d_panel_eval(chnkr, 'd', ...
+                sigma(k,:).', targ_r, dlim, eval_opts);
+            val(k,:) = val(k,:) + alpha_D * uk(:).';
+        end
+        udv = chnk.kernsplit.sto2d_panel_eval(chnkr, 'd', mu, sigma, ...
+            targ_r, dlim, eval_opts);
+        val = val + alpha_Kdvel * udv;
+        % +η ε_ij ∫(r×n_y)/r² σ_j ds
+        u_orth = orthogonal_cauchy_panel_eval(chnkr, sigma, targ_r, ...
+            dlim, eval_opts, 'src');
+        val(1,:) = val(1,:) + ( eta) * u_orth(2,:);
+        val(2,:) = val(2,:) + (-eta) * u_orth(1,:);
+
+    % ========================== Dalt ============================
+    case 'dalt'
+        for k = 1:2
+            uk = chnk.kernsplit.lap2d_panel_eval(chnkr, 'd', ...
+                sigma(k,:).', targ_r, dlim, eval_opts);
+            val(k,:) = val(k,:) + alpha_Dalt * uk(:).';
+        end
+        udv = chnk.kernsplit.sto2d_panel_eval(chnkr, 'd', mu, sigma, ...
+            targ_r, dlim, eval_opts);
+        val = val + alpha_Kdvel * udv;
+
+    % ========================== Strac ===========================
+    case {'strac','straction'}
+        if isempty(targ_n)
+            error(['CHNK.KERNSPLIT.ELAST2D_PANEL_EVAL: ''strac'' requires ' ...
+                   'target normals (pass targets as struct with .n)']);
+        end
+        % Lap_Sp piece (per component, target-normal)
+        targ_struct = struct('r', targ_r, 'n', targ_n);
+        for k = 1:2
+            uk = chnk.kernsplit.lap2d_panel_eval(chnkr, 'sp', ...
+                sigma(k,:).', targ_struct, dlim, eval_opts);
+            val(k,:) = val(k,:) + alpha_Sp * uk(:).';
+        end
+        % +η ε_ij ∫(r×n_t)/r² σ_j ds, target-normal flavor
+        u_orth = orthogonal_cauchy_panel_eval(chnkr, sigma, targ_r, ...
+            dlim, eval_opts, 'tgt', targ_n);
+        val(1,:) = val(1,:) + ( eta) * u_orth(2,:);
+        val(2,:) = val(2,:) + (-eta) * u_orth(1,:);
+        % ζ r_i r_j (r.n_t)/r^4 piece: Stokes-strac panel-eval (full Wu-Barnett).
+        % ζ r_i r_j (r.n_t)/r^4 = -π ζ * K_stokes_strac (chunkie convention
+        % K_stokes_strac = -(1/π) r_i r_j (r.n_t)/r⁴).
+        u_strac_stokes = chnk.kernsplit.sto2d_panel_eval(chnkr, 'strac', mu, ...
+            sigma, targ_struct, dlim, eval_opts);
+        val = val + (-pi*zeta) * u_strac_stokes;
+
+    otherwise
+        error('CHNK.KERNSPLIT.ELAST2D_PANEL_EVAL: unknown type %s', type);
+end
+end
+
+
+% ------------------------------------------------------------------
+function u_orth = orthogonal_cauchy_panel_eval(chnkr, sigma, targ_r, ...
+    dlim, eval_opts, mode, targ_n_in)
+% Evaluate v_k(x) = ∫ K(x,y) σ_k(y) ds over Γ where
+%   K = (r × n_y)/r²    (mode='src')
+%   K = (r × n_t)/r²    (mode='tgt')  -- requires target normals
+% with wLCHS close correction (Im(CauC) or Im(nzt·CauC./nz)).
+
+if nargin < 7, targ_n_in = []; end
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+nt  = size(targ_r, 2);
+
+[~, wgl] = lege.exps(ngl);
+zsrc_all = (chnkr.r(1,:,:) + 1i*chnkr.r(2,:,:)); zsrc_all = zsrc_all(:).';
+nz_all   = (chnkr.n(1,:,:) + 1i*chnkr.n(2,:,:)); nz_all   = nz_all(:).';
+awzp_all = chnkr.wts(:).';
+d_all    = (chnkr.d(1,:,:) + 1i*chnkr.d(2,:,:)); d_all    = d_all(:).';
+wgl_rep  = repmat(wgl(:).', 1, nch);
+wzp_all  = d_all .* wgl_rep;
+
+ztgt = targ_r(1,:).' + 1i*targ_r(2,:).';
+if strcmp(mode,'tgt')
+    if isempty(targ_n_in)
+        error('orthogonal_cauchy_panel_eval: tgt mode requires target normals');
+    end
+    nzt = (targ_n_in(1,:) + 1i*targ_n_in(2,:)).';
+end
+
+% Smooth far-field: sum_j K(x,y_j) σ_j awzp_j (vectorized over targets).
+% Compute the 1-component contribution K · σ separately for σ_1 and σ_2.
+% K = Im(n_y/δ) (src mode) or Im(n_t/δ) (tgt mode), δ = x - y.
+% n_y/δ for src mode: complex 1 x npt per target i.
+% Vectorized: build nt x npt matrix of K_ij, then matmul with σ_k.
+%
+% This is the same cost as chunkerkerneval direct smooth, no FMM.  For
+% large nt, npt this dominates; optimize later via chunkerkerneval(lap
+% hilb kernel) if needed.
+diff_full = ztgt - zsrc_all;                % nt x npt
+ny_over_d = nz_all ./ diff_full .* (-1);    % n_y / (x-y) = -n_y/(y-x).
+% Wait: we want n_y / δ = n_y / (x - y).  Compute directly:
+ny_over_d = nz_all ./ diff_full;            % nt x npt complex
+% K_src = Im(n_y/δ), K_tgt = Im(n_t/δ).
+switch mode
+    case 'src'
+        K_full = imag(ny_over_d);
+    case 'tgt'
+        nt_over_d = nzt ./ diff_full;       % nt x npt complex
+        K_full = imag(nt_over_d);
+    otherwise
+        error('orthogonal_cauchy_panel_eval: unknown mode %s', mode);
+end
+K_full = K_full .* awzp_all;                % bake in arclength weights
+
+u_orth = zeros(2, nt);
+for k = 1:2
+    u_orth(k,:) = (K_full * sigma(k,:).').';
+end
+
+% Per-panel close correction (poly - smooth)
+[rends,~] = chunkends(chnkr);
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));
+panlen = zeros(nch,1);
+for ip = 1:nch
+    panlen(ip) = sum(awzp_all((ip-1)*ngl+(1:ngl)));
+end
+dlim2 = dlim^2;
+
+for ip = 1:nch
+    pidx = (ip-1)*ngl + (1:ngl);
+    zsrc_p = zsrc_all(pidx);
+    nz_p   = nz_all(pidx);
+    wzp_p  = wzp_all(pidx);
+    awzp_p = awzp_all(pidx);
+    a = endsa(ip); b = endsb(ip);
+
+    diff_p = ztgt - zsrc_p;
+    d2_p   = real(diff_p).*real(diff_p) + imag(diff_p).*imag(diff_p);
+    near   = min(d2_p, [], 2) < dlim2*panlen(ip)^2;
+    if ~any(near); continue; end
+
+    ztgt_near = ztgt(near);
+    U = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc_p);
+    [~, CauC] = chnk.kernsplit.wlchs_target(a, b, ztgt_near, ...
+        zsrc_p, nz_p, wzp_p, awzp_p, U, 0);
+
+    % close - smooth correction matrix per source for the integral
+    % ∫ K(x,y) σ ds where K is (r × n)/r² (src or tgt normal).
+    % Recall: (r × n_y)/r² · awzp_smooth = -Im(tcau); close - smooth = -Im(CauC).
+    %         (r × n_t)/r² · awzp_smooth = -Im(nzt·tcau/nz); correction = -Im(nzt·CauC/nz).
+    switch mode
+        case 'src'
+            Mc = -imag(CauC);                       % nt_near x ngl
+        case 'tgt'
+            Mc = -imag(nzt(near) .* (CauC ./ nz_p));% nt_near x ngl
+    end
+
+    sigma_p_1 = sigma(1, pidx).';
+    sigma_p_2 = sigma(2, pidx).';
+    u_orth(1, near) = u_orth(1, near) + (Mc * sigma_p_1).';
+    u_orth(2, near) = u_orth(2, near) + (Mc * sigma_p_2).';
+end
+end
+
+

--- a/chunkie/+chnk/+kernsplit/elast2d_self_correction.m
+++ b/chunkie/+chnk/+kernsplit/elast2d_self_correction.m
@@ -1,0 +1,240 @@
+function [delta, U_src_cell] = elast2d_self_correction(chnkr, type, lam, mu, U_src_cell)
+%CHNK.KERNSPLIT.ELAST2D_SELF_CORRECTION  self-panel close correction for
+% 2D linear elasticity layer potentials, decomposed by sub-block.
+%
+% Chunkie elasticity convention (chnk.elast2d.kern):
+%   beta  = (lam+3mu)/(4 pi mu (lam+2mu))
+%   gamma = -(lam+mu)/(4 pi mu (lam+2mu))
+%   eta   = mu/(2 pi (lam+2mu))
+%   zeta  = (lam+mu)/(pi (lam+2mu))
+%
+% [S]_ij    = (beta log r + gamma/2) delta_ij + gamma r_i r_j / r^2
+% [D]_ij    = -eta (r.n_y)/r^2 delta_ij + eta (r x n_y)/r^2 epsilon_ij ...
+%             - zeta r_i r_j (r.n_y)/r^4
+%             (epsilon_12 = -1, epsilon_21 = +1)
+% [Strac]_ij= +eta (r.n_t)/r^2 delta_ij + eta (r x n_t)/r^2 sigma_ij ...
+%             + zeta r_i r_j (r.n_t)/r^4
+%             (sigma_12 = +1, sigma_21 = -1)
+% [Dalt]_ij = -2 eta (r.n_y)/r^2 delta_ij - zeta r_i r_j (r.n_y)/r^4
+%
+% Singularity structure of each sub-block on a smooth boundary:
+%   S xx,yy  :  log + bounded (uses Laplace S wLCHS + analytic diag limit)
+%   S xy=yx  :  bounded only (analytic diag limit)
+%   D xx,yy  :  bounded only (analytic diag limit, (r.n_y) gives kappa/2)
+%   D xy,yx  :  source-normal Cauchy + bounded
+%   Strac xx,yy: bounded only
+%   Strac xy,yx: target-normal Cauchy + bounded
+%   Dalt all  :  bounded only
+%
+% Chunkie convention:  awzp_j * n_y_complex = -i * wzp_j  (CCW + outward),
+% dn/ds = +kappa tau  giving  (r.n_y)/r^2 -> -kappa/2  along the curve,
+%                              (r.n_t)/r^2 -> +kappa/2.
+%
+% Cauchy close corrections (close minus smooth, per kernel * awzp_j).
+% Using chunkie tcau = wzp/(y-x)/i and awzp*n_y = -i*wzp (CCW outward):
+%   (r.n_y)/r^2 * awzp_smooth   = -Re(tcau)             --> -Re(CauC)
+%   (r x n_y)/r^2 * awzp_smooth = -Im(tcau)             --> -Im(CauC)
+%   (r.n_t)/r^2 * awzp_smooth   = -Re(nzt.*tcau./nz)    --> -Re(nzt.*CauC./nz)
+%   (r x n_t)/r^2 * awzp_smooth = -Im(nzt.*tcau./nz)    --> -Im(nzt.*CauC./nz)
+%
+% Inputs:
+%   chnkr       - chunker
+%   type        - sub-block label, one of
+%                 's_xx','s_xy','s_yx','s_yy',
+%                 'd_xx','d_xy','d_yx','d_yy',
+%                 'strac_xx','strac_xy','strac_yx','strac_yy',
+%                 'dalt_xx','dalt_xy','dalt_yx','dalt_yy'
+%   lam, mu     - Lame parameters
+%   U_src_cell  - cached per-panel inverse Vandermonde from prior calls
+%
+% Output: sparse npt x npt delta matrix following the chunkermat forcewlchs
+%   convention --
+%     diagonal entries  = FULL close-eval matrix entry (M_smooth diag is
+%                         zeroed by the caller),
+%     off-diagonal      = (close - smooth) of the matrix entry,
+%   so that  M_smooth + delta  = full close-eval block matrix.
+
+if nargin < 5 || isempty(U_src_cell)
+    U_src_cell = cell(1, chnkr.nch);
+end
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+N   = chnkr.npt;
+d   = chnkr.d(:,:);
+d2  = chnkr.d2(:,:);
+w   = chnkr.wts(:);
+spd = sqrt(d(1,:).^2 + d(2,:).^2).';
+tx  = d(1,:).' ./ spd;
+ty  = d(2,:).' ./ spd;
+kappa = (d(1,:).*d2(2,:) - d(2,:).*d2(1,:)).' ./ spd.^3;
+
+% material coefficients (match chnk.elast2d.kern)
+beta  = (lam + 3*mu) / (4*pi*mu*(lam + 2*mu));
+gamma = -(lam + mu) / (4*pi*mu*(lam + 2*mu));
+eta   = mu / (2*pi*(lam + 2*mu));
+zeta  = (lam + mu) / (pi*(lam + 2*mu));
+
+tlow = lower(type);
+
+switch tlow
+    % ------------------------------- S -------------------------------
+    case 's_xx'
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction( ...
+            chnkr, 's', U_src_cell);
+        bounded_diag = (gamma/2 + gamma * tx.^2) .* w;
+        delta = (-2*pi*beta) * lap_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case 's_yy'
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction( ...
+            chnkr, 's', U_src_cell);
+        bounded_diag = (gamma/2 + gamma * ty.^2) .* w;
+        delta = (-2*pi*beta) * lap_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case {'s_xy', 's_yx'}
+        bounded_diag = gamma * tx .* ty .* w;
+        delta = sparse(1:N, 1:N, bounded_diag, N, N);
+
+    % ------------------------------- D -------------------------------
+    % D(1,1), D(2,2) include -eta*(r.n_y)/r^2 which is -2*pi*eta * Lap_D;
+    % Lap_D's wLCHS captures both diagonal limit and off-diagonal close
+    % correction.  Bounded zeta r_i^2 (r.n_y)/r^4 piece keeps the analytic
+    % diagonal limit only (matching the Stokes dvel pattern).
+    case 'd_xx'
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction( ...
+            chnkr, 'd', U_src_cell);
+        bounded_diag = (kappa/2) .* zeta .* tx.^2 .* w;
+        delta = (-2*pi*eta) * lap_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case 'd_yy'
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction( ...
+            chnkr, 'd', U_src_cell);
+        bounded_diag = (kappa/2) .* zeta .* ty.^2 .* w;
+        delta = (-2*pi*eta) * lap_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case 'd_xy'
+        % D(1,2) = +eta (r x n_y)/r^2 - zeta r_x r_y (r.n_y)/r^4.
+        % Cauchy piece: +eta * Im(CauC) on off-diag + diag.
+        % Bounded piece diag: -zeta tx*ty * (-kappa/2) = +(kappa/2) zeta tx*ty.
+        [Cau_delta, U_src_cell] = elast2d_cauchy_self_block( ...
+            chnkr, 'src_im', U_src_cell);
+        bounded_diag = (kappa/2) .* zeta .* tx .* ty .* w;
+        delta = (+eta) * Cau_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case 'd_yx'
+        % D(2,1) = -eta (r x n_y)/r^2 - zeta r_x r_y (r.n_y)/r^4.
+        [Cau_delta, U_src_cell] = elast2d_cauchy_self_block( ...
+            chnkr, 'src_im', U_src_cell);
+        bounded_diag = (kappa/2) .* zeta .* tx .* ty .* w;
+        delta = (-eta) * Cau_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    % ----------------------------- Strac -----------------------------
+    % The eta*(r.n_t)/r^2 piece is Laplace S' up to scale; needs the same
+    % off-diagonal Cauchy correction (Re(nzt.*CauC./nz)) as Lap S'.  The
+    % zeta r_i r_j (r.n_t)/r^4 piece is smooth on a closed curve and only
+    % needs the analytic diagonal limit (matching Stokes strac).
+    case 'strac_xx'
+        % eta*(r.n_t)/r^2 piece via Lap S'-style correction:
+        %   eta*(r.n_t)/r^2 = -2*pi*eta * Lap_S' (Lap_S' = -(r.n_t)/(2 pi r^2)).
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction( ...
+            chnkr, 'sp', U_src_cell);
+        bounded_diag = (kappa/2) .* zeta .* tx.^2 .* w;
+        delta = (-2*pi*eta) * lap_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case 'strac_yy'
+        [lap_delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction( ...
+            chnkr, 'sp', U_src_cell);
+        bounded_diag = (kappa/2) .* zeta .* ty.^2 .* w;
+        delta = (-2*pi*eta) * lap_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case 'strac_xy'
+        % Strac(1,2) = +eta (r x n_t)/r^2 + zeta r_x r_y (r.n_t)/r^4.
+        [Cau_delta, U_src_cell] = elast2d_cauchy_self_block( ...
+            chnkr, 'tgt_im', U_src_cell);
+        bounded_diag = (kappa/2) .* zeta .* tx .* ty .* w;
+        delta = (+eta) * Cau_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    case 'strac_yx'
+        % Strac(2,1) = -eta (r x n_t)/r^2 + zeta r_x r_y (r.n_t)/r^4.
+        [Cau_delta, U_src_cell] = elast2d_cauchy_self_block( ...
+            chnkr, 'tgt_im', U_src_cell);
+        bounded_diag = (kappa/2) .* zeta .* tx .* ty .* w;
+        delta = (-eta) * Cau_delta + sparse(1:N, 1:N, bounded_diag, N, N);
+
+    % ----------------------------- Dalt ------------------------------
+    case 'dalt_xx'
+        % Dalt(1,1) = -2 eta (r.n_y)/r^2 - zeta r_x^2 (r.n_y)/r^4; both
+        % bounded.  (r.n_y)/r^2 -> -kappa/2 so diag = +(kappa/2)(2 eta + zeta tx^2).
+        diag_v = (kappa/2) .* (2*eta + zeta * tx.^2) .* w;
+        delta = sparse(1:N, 1:N, diag_v, N, N);
+
+    case 'dalt_yy'
+        diag_v = (kappa/2) .* (2*eta + zeta * ty.^2) .* w;
+        delta = sparse(1:N, 1:N, diag_v, N, N);
+
+    case {'dalt_xy', 'dalt_yx'}
+        diag_v = (kappa/2) .* zeta .* tx .* ty .* w;
+        delta = sparse(1:N, 1:N, diag_v, N, N);
+
+    otherwise
+        error('CHNK.KERNSPLIT.ELAST2D_SELF_CORRECTION: type %s not supported', type);
+end
+
+end
+
+
+function [Cau, U_src_cell] = elast2d_cauchy_self_block(chnkr, mode, U_src_cell)
+% Build sparse npt x npt close-correction matrix for the SELF block of an
+% elasticity Cauchy piece.
+%   mode = 'src_im' : delta = Im(CauC)   (source-normal cross piece)
+%   mode = 'tgt_im' : delta = Im(nzt .* CauC ./ nz)  (target-normal cross)
+%
+% On-diagonal entries are the full polynomial wLCHS value (CauC was built
+% with ifself = 1 so the diagonal of CauC carries the analytic on-curve
+% PV).  Off-diagonal entries are the wLCHS delta over smooth GL.
+
+ngl = chnkr.k;
+nch = chnkr.nch;
+N   = chnkr.npt;
+
+[~, wgl] = lege.exps(ngl);
+[rends, ~] = chunkends(chnkr);
+endsa = squeeze(rends(1,1,:) + 1i*rends(2,1,:));
+endsb = squeeze(rends(1,2,:) + 1i*rends(2,2,:));
+
+ii = []; jj = []; vv = [];
+for ip = 1:nch
+    idx  = (ip-1)*ngl + (1:ngl);
+    zsrc = chnkr.r(1,:,ip) + 1i*chnkr.r(2,:,ip);
+    nz   = chnkr.n(1,:,ip) + 1i*chnkr.n(2,:,ip);
+    dz   = chnkr.d(1,:,ip) + 1i*chnkr.d(2,:,ip);
+    awzp = chnkr.wts(:,ip).';
+    wzp  = dz .* wgl(:).';
+    a = endsa(ip); b = endsb(ip);
+
+    ztgt = zsrc(:); nzt = nz(:);
+
+    if isempty(U_src_cell{ip})
+        U_src_cell{ip} = chnk.kernsplit.wlchs_src_precomp(a, b, zsrc);
+    end
+    U_src = U_src_cell{ip};
+
+    [~, CauC] = chnk.kernsplit.wlchs_target(a, b, ztgt, zsrc, nz, ...
+        wzp, awzp, U_src, 1);
+
+    switch mode
+        case 'src_im'
+            Mblk = -imag(CauC);
+        case 'tgt_im'
+            Mblk = -imag(nzt .* (CauC ./ nz));
+        otherwise
+            error('elast2d_cauchy_self_block: unknown mode %s', mode);
+    end
+
+    [I, J] = ndgrid(idx, idx);
+    ii = [ii; I(:)];
+    jj = [jj; J(:)];
+    vv = [vv; Mblk(:)];
+end
+Cau = sparse(ii, jj, vv, N, N);
+end

--- a/chunkie/chunkerkerneval.m
+++ b/chunkie/chunkerkerneval.m
@@ -53,9 +53,10 @@ function [fints,ids] = chunkerkerneval(chnkobj,kern,dens,targobj,opts)
 %       opts.eps = tolerance for adaptive integration
 %       opts.forcewlchs - if = true, use kernel-split (Helsing-style)
 %               panel quadrature for close evaluation. Supports
-%               Helmholtz (s/d/sp) and Laplace (s/d/sp) scalar kernels
-%               -- kern must be a single kernel object. Delivers 10+
-%               digits of accuracy at close off-curve targets. (false)
+%               Helmholtz (s/d/sp), Laplace (s/d/sp), and elasticity
+%               (s/d/strac/dalt; opdims=[2 2]) kernels -- kern must be
+%               a single kernel object. Delivers 10+ digits of accuracy
+%               at close off-curve targets. (false)
 %
 % output:
 %   fints - opdims(1) x nt array of integral values where opdims is the 
@@ -156,17 +157,24 @@ else
 end
 
 if use_wlchs
-    % Single scalar kernel (helm/lap, opdims=[1 1]).
+    % Single kernel: scalar (helm/lap, opdims=[1 1]) or elasticity (opdims=[2 2]).
     if size(kern,1) ~= 1 || size(kern,2) ~= 1 || ~isa(kern,'kernel')
         error("CHUNKERKERNEVAL: forcewlchs=true requires a single kernel object");
     end
-    is_helm = strcmpi(kern.name, 'helmholtz');
-    is_lap  = strcmpi(kern.name, 'laplace');
-    if ~is_helm && ~is_lap
-        error("CHUNKERKERNEVAL: forcewlchs supports Helmholtz or Laplace kernels");
+    is_helm  = strcmpi(kern.name, 'helmholtz');
+    is_lap   = strcmpi(kern.name, 'laplace');
+    is_elast = strcmpi(kern.name, 'elasticity');
+    if ~is_helm && ~is_lap && ~is_elast
+        error("CHUNKERKERNEVAL: forcewlchs supports Helmholtz, Laplace, or elasticity kernels");
     end
-    if ~ismember(lower(kern.type), {'s','single','d','double','sp','sprime'})
-        error("CHUNKERKERNEVAL: forcewlchs currently supports only s/d/sp layers");
+    if is_elast
+        if ~ismember(lower(kern.type), {'s','single','d','double','strac','straction','dalt'})
+            error("CHUNKERKERNEVAL: forcewlchs (elasticity) supports types s, d, strac, dalt");
+        end
+    else
+        if ~ismember(lower(kern.type), {'s','single','d','double','sp','sprime'})
+            error("CHUNKERKERNEVAL: forcewlchs currently supports only s/d/sp layers");
+        end
     end
     wlchs_type   = kern.type;
     wlchs_family = kern.name;
@@ -187,7 +195,7 @@ if use_wlchs
             base_probe = -0.25i * wlchs_zk * besselh(1, wlchs_zk);
         end
         wlchs_coef = val_probe / base_probe;
-    else  % laplace
+    elseif is_lap
         wlchs_zk = [];
         if strcmpi(wlchs_type,'s') || strcmpi(wlchs_type,'single')
             tgt_probe.r = [2;0];
@@ -197,23 +205,45 @@ if use_wlchs
             base_probe = 1/(2*pi);
         end
         wlchs_coef = val_probe / base_probe;
+    else  % elasticity
+        if ~isfield(kern.params,'lam') || isempty(kern.params.lam) || ...
+           ~isfield(kern.params,'mu')  || isempty(kern.params.mu)
+            error("CHUNKERKERNEVAL: forcewlchs (elasticity) requires kern.params.lam and kern.params.mu");
+        end
+        wlchs_lam = kern.params.lam;
+        wlchs_mu  = kern.params.mu;
+        wlchs_zk  = [];
+        % Probe far from r=0 for log/Cauchy stability
+        tgt_probe.r = [2;0];
+        val_probe = kern.eval(src_probe, tgt_probe);
+        switch lower(wlchs_type)
+            case {'s','single'},        et = 's';
+            case {'d','double'},        et = 'd';
+            case {'strac','straction'}, et = 'strac';
+            case 'dalt',                et = 'dalt';
+        end
+        base_probe = chnk.elast2d.kern(wlchs_lam, wlchs_mu, src_probe, ...
+            tgt_probe, et);
+        wlchs_coef = val_probe(1,1) / base_probe(1,1);
     end
 
     % Non-rcipsav path: dispatch directly to kernsplit on the (possibly
     % merged) chunker. Targets pass through as raw point coords or struct
-    % with .r and .n when normals are needed (sp).
+    % with .r and .n when normals are needed (sp; elasticity strac).
     if length(chnkr) > 1
         chnkr_use = merge(chnkr);
     else
         chnkr_use = chnkr;
     end
     targ_pts = local_target_points(targobj);
-    needs_tgt_normals = any(strcmpi(wlchs_type, {'sp','sprime'}));
+    is_strac_helm = any(strcmpi(wlchs_type, {'sp','sprime'}));
+    is_strac_elast = is_elast && any(strcmpi(wlchs_type, {'strac','straction'}));
+    needs_tgt_normals = is_strac_helm || is_strac_elast;
     targ_n = [];
     if needs_tgt_normals
         targ_n = local_target_normals(targobj);
         if isempty(targ_n)
-            error(['CHUNKERKERNEVAL: forcewlchs with sp kernel ' ...
+            error(['CHUNKERKERNEVAL: forcewlchs with sp/strac kernel ' ...
                    'requires target normals; pass targobj as a struct with .n']);
         end
     end
@@ -233,6 +263,16 @@ if use_wlchs
         case 'laplace'
             fints = wlchs_coef * chnk.kernsplit.lap2d_panel_eval(chnkr_use, ...
                 wlchs_type, dens, targ_for_eval, [], hpe_opts);
+        case 'elasticity'
+            switch lower(wlchs_type)
+                case {'s','single'},        et = 's';
+                case {'d','double'},        et = 'd';
+                case {'strac','straction'}, et = 'strac';
+                case 'dalt',                et = 'dalt';
+            end
+            val = chnk.kernsplit.elast2d_panel_eval(chnkr_use, et, ...
+                wlchs_lam, wlchs_mu, dens, targ_for_eval, [], hpe_opts);
+            fints = wlchs_coef * val(:);
         otherwise
             error('CHUNKERKERNEVAL: forcewlchs family %s not supported', wlchs_family);
     end

--- a/chunkie/chunkermat.m
+++ b/chunkie/chunkermat.m
@@ -857,7 +857,35 @@ if islogical(fw) || (isnumeric(fw) && isscalar(fw))
         error("chunkermat: opts.forcewlchs=true requires a single helm2d, lap2d, or stok2d kernel");
     end
     t = lower(kern.type);
-    if strcmp(fam, 'stokes')
+    if strcmp(fam, 'elasticity')
+        % Elasticity SLP/DLP/Strac/Dalt are 2x2 opdims kernels; populate
+        % the 4 sub-block layout cells.  Supported: s, d, strac, dalt.
+        if ismember(t, {'s','single'})
+            el_kind = 's';
+        elseif ismember(t, {'d','double'})
+            el_kind = 'd';
+        elseif ismember(t, {'strac','straction'})
+            el_kind = 'strac';
+        elseif ismember(t, {'dalt'})
+            el_kind = 'dalt';
+        else
+            error("chunkermat: opts.forcewlchs=true: elast2d kernel type %s not supported", kern.type);
+        end
+        if m ~= 2 || n ~= 2
+            error("chunkermat: opts.forcewlchs=true on elast2d '%s' requires opdims=[2 2]", el_kind);
+        end
+        if ~isfield(kern.params, 'lam') || isempty(kern.params.lam) || ...
+           ~isfield(kern.params, 'mu')  || isempty(kern.params.mu)
+            error("chunkermat: opts.forcewlchs (elasticity) requires kern.params.lam and kern.params.mu");
+        end
+        lam = kern.params.lam;
+        mu  = kern.params.mu;
+        coef = wlchs_extract_scalar(kern, el_kind, [lam, mu], 'elasticity');
+        layout{1,1} = struct('type',[el_kind '_xx'],'coef',coef,'lam',lam,'mu',mu,'family','elasticity');
+        layout{1,2} = struct('type',[el_kind '_xy'],'coef',coef,'lam',lam,'mu',mu,'family','elasticity');
+        layout{2,1} = struct('type',[el_kind '_yx'],'coef',coef,'lam',lam,'mu',mu,'family','elasticity');
+        layout{2,2} = struct('type',[el_kind '_yy'],'coef',coef,'lam',lam,'mu',mu,'family','elasticity');
+    elseif strcmp(fam, 'stokes')
         % Stokes velocity SLP/DLP is a 2x2 opdims kernel; populate the 4
         % sub-block layout cells.  Supported: 'svel' (single layer),
         % 'dvel' (double layer), 'strac' (traction).
@@ -925,13 +953,15 @@ elseif isstruct(fw)
     if isfield(fw, 'family') && ~isempty(fw.family)
         fam_default = lower(fw.family);
     end
-    if ~ismember(fam_default, {'helmholtz','laplace','stokes'})
-        error("chunkermat: opts.forcewlchs.family must be 'helmholtz', 'laplace', or 'stokes'");
+    if ~ismember(fam_default, {'helmholtz','laplace','stokes','elasticity'})
+        error("chunkermat: opts.forcewlchs.family must be 'helmholtz', 'laplace', 'stokes', or 'elasticity'");
     end
     zk_default = [];
     mu_default = [];
+    lam_default = [];
     if isfield(fw, 'zk') && ~isempty(fw.zk), zk_default = fw.zk; end
     if isfield(fw, 'mu') && ~isempty(fw.mu), mu_default = fw.mu; end
+    if isfield(fw, 'lam') && ~isempty(fw.lam), lam_default = fw.lam; end
 
     L = fw.layout;
     if ~iscell(L) || size(L,1) ~= m || size(L,2) ~= n
@@ -944,6 +974,7 @@ elseif isstruct(fw)
             ent_fam = fam_default;
             ent_zk  = zk_default;
             ent_mu  = mu_default;
+            ent_lam = lam_default;
             if iscell(entry)
                 t = entry{1}; a = entry{2};
             elseif isstruct(entry)
@@ -956,8 +987,9 @@ elseif isstruct(fw)
                 if isfield(entry, 'family') && ~isempty(entry.family)
                     ent_fam = lower(entry.family);
                 end
-                if isfield(entry, 'zk') && ~isempty(entry.zk), ent_zk = entry.zk; end
-                if isfield(entry, 'mu') && ~isempty(entry.mu), ent_mu = entry.mu; end
+                if isfield(entry, 'zk')  && ~isempty(entry.zk),  ent_zk  = entry.zk;  end
+                if isfield(entry, 'mu')  && ~isempty(entry.mu),  ent_mu  = entry.mu;  end
+                if isfield(entry, 'lam') && ~isempty(entry.lam), ent_lam = entry.lam; end
             else
                 error("chunkermat: opts.forcewlchs.layout{%d,%d} bad form", r, c);
             end
@@ -979,6 +1011,14 @@ elseif isstruct(fw)
                     if isempty(ent_mu)
                         error("chunkermat: forcewlchs stokes layout entry (%d,%d) needs mu", r, c);
                     end
+                case 'elasticity'
+                    allowed_e = {'s_xx','s_xy','s_yx','s_yy', ...
+                                 'd_xx','d_xy','d_yx','d_yy', ...
+                                 'strac_xx','strac_xy','strac_yx','strac_yy', ...
+                                 'dalt_xx','dalt_xy','dalt_yx','dalt_yy'};
+                    if isempty(ent_lam) || isempty(ent_mu)
+                        error("chunkermat: forcewlchs elasticity layout entry (%d,%d) needs lam and mu", r, c);
+                    end
                 otherwise
                     error("chunkermat: unknown family %s", ent_fam);
             end
@@ -991,16 +1031,19 @@ elseif isstruct(fw)
                     error("chunkermat: forcewlchs c layout entry needs coefs [c1, c2]");
                 end
                 layout{r,c} = struct('type', 'c', 'coefs', a(:).', ...
-                                     'zk', ent_zk, 'mu', ent_mu, 'family', ent_fam);
+                                     'zk', ent_zk, 'mu', ent_mu, ...
+                                     'lam', ent_lam, 'family', ent_fam);
             elseif strcmpi(t, 'sc') || strcmpi(t, 'spcombined')
                 if ~isvector(a) || numel(a) ~= 2
                     error("chunkermat: forcewlchs sc layout entry needs coefs [c1, c2]");
                 end
                 layout{r,c} = struct('type', 'sc', 'coefs', a(:).', ...
-                                     'zk', ent_zk, 'mu', ent_mu, 'family', ent_fam);
+                                     'zk', ent_zk, 'mu', ent_mu, ...
+                                     'lam', ent_lam, 'family', ent_fam);
             else
                 layout{r,c} = struct('type', lower(t), 'coef', a, ...
-                                     'zk', ent_zk, 'mu', ent_mu, 'family', ent_fam);
+                                     'zk', ent_zk, 'mu', ent_mu, ...
+                                     'lam', ent_lam, 'family', ent_fam);
             end
         end
     end
@@ -1162,14 +1205,15 @@ end
 end
 
 function fam = wlchs_kernel_family(kern)
-% Returns 'helmholtz', 'laplace', 'stokes', or '' if the kernel is
-% unsupported by the wLCHS path.
+% Returns 'helmholtz', 'laplace', 'stokes', 'elasticity', or '' if the
+% kernel is unsupported by the wLCHS path.
 fam = '';
 if ~isa(kern, 'kernel'), return; end
 if strcmpi(kern.name, 'zeros'), return; end
-if strcmpi(kern.name, 'helmholtz'), fam = 'helmholtz'; return; end
-if strcmpi(kern.name, 'laplace'),   fam = 'laplace';   return; end
-if strcmpi(kern.name, 'stokes'),    fam = 'stokes';    return; end
+if strcmpi(kern.name, 'helmholtz'),  fam = 'helmholtz';  return; end
+if strcmpi(kern.name, 'laplace'),    fam = 'laplace';    return; end
+if strcmpi(kern.name, 'stokes'),     fam = 'stokes';     return; end
+if strcmpi(kern.name, 'elasticity'), fam = 'elasticity'; return; end
 end
 
 function tf = wlchs_has_self_correction(type, family)
@@ -1192,6 +1236,11 @@ switch lower(family)
         tf = ismember(lower(type), {'svel_xx','svel_xy','svel_yx','svel_yy', ...
                                      'dvel_xx','dvel_xy','dvel_yx','dvel_yy', ...
                                      'strac_xx','strac_xy','strac_yx','strac_yy'});
+    case 'elasticity'
+        tf = ismember(lower(type), {'s_xx','s_xy','s_yx','s_yy', ...
+                                     'd_xx','d_xy','d_yx','d_yy', ...
+                                     'strac_xx','strac_xy','strac_yx','strac_yy', ...
+                                     'dalt_xx','dalt_xy','dalt_yx','dalt_yy'});
     otherwise
         tf = false;
 end
@@ -1208,6 +1257,9 @@ switch lower(spec.family)
         [delta, U_src_cell] = chnk.kernsplit.lap2d_self_correction(chnkr, type, U_src_cell);
     case 'stokes'
         [delta, U_src_cell] = chnk.kernsplit.sto2d_self_correction(chnkr, type, spec.mu, U_src_cell);
+    case 'elasticity'
+        [delta, U_src_cell] = chnk.kernsplit.elast2d_self_correction( ...
+            chnkr, type, spec.lam, spec.mu, U_src_cell);
     otherwise
         error('wlchs_self_correction_dispatch: unsupported family %s', spec.family);
 end
@@ -1221,6 +1273,9 @@ switch lower(spec.family)
         [delta, U_src_cell] = chnk.kernsplit.lap2d_adj_correction(chnkr, type, U_src_cell);
     case 'stokes'
         [delta, U_src_cell] = chnk.kernsplit.sto2d_adj_correction(chnkr, type, spec.mu, U_src_cell);
+    case 'elasticity'
+        [delta, U_src_cell] = chnk.kernsplit.elast2d_adj_correction( ...
+            chnkr, type, spec.lam, spec.mu, U_src_cell);
     otherwise
         error('wlchs_adj_correction_dispatch: unsupported family %s', spec.family);
 end
@@ -1281,6 +1336,28 @@ switch lower(spec.family)
             otherwise
                 error('wlchs_kernel_eval: stokes sub-block %s not supported', sub);
         end
+    case 'elasticity'
+        tlow = lower(type);
+        if startsWith(tlow, 's_')
+            K_full = chnk.elast2d.kern(spec.lam, spec.mu, si, ti, 's');
+        elseif startsWith(tlow, 'd_')
+            K_full = chnk.elast2d.kern(spec.lam, spec.mu, si, ti, 'd');
+        elseif startsWith(tlow, 'strac_')
+            K_full = chnk.elast2d.kern(spec.lam, spec.mu, si, ti, 'strac');
+        elseif startsWith(tlow, 'dalt_')
+            K_full = chnk.elast2d.kern(spec.lam, spec.mu, si, ti, 'dalt');
+        else
+            error('wlchs_kernel_eval: elasticity type %s not supported', type);
+        end
+        sub = tlow(end-1:end);
+        switch sub
+            case 'xx', K = K_full(1:2:end, 1:2:end);
+            case 'xy', K = K_full(1:2:end, 2:2:end);
+            case 'yx', K = K_full(2:2:end, 1:2:end);
+            case 'yy', K = K_full(2:2:end, 2:2:end);
+            otherwise
+                error('wlchs_kernel_eval: elasticity sub-block %s not supported', sub);
+        end
     otherwise
         error('wlchs_kernel_eval: unsupported family %s', spec.family);
 end
@@ -1295,7 +1372,7 @@ function coef = wlchs_extract_scalar(kern, t, param, family)
 %
 % `param` carries family-specific data (zk for helmholtz, [] for laplace).
 if nargin < 4 || isempty(family), family = 'helmholtz'; end
-if strcmp(family, 'laplace') || strcmp(family, 'stokes')
+if strcmp(family, 'laplace') || strcmp(family, 'stokes') || strcmp(family, 'elasticity')
     src_probe = struct('r',[0;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
     tgt_probe = struct('r',[2;0],'n',[1;0],'d',[1;0],'d2',[0;0]);
 else
@@ -1342,6 +1419,23 @@ switch lower(family)
             base = chnk.stok2d.kern(mu, src_probe, tgt_probe, 'strac');
         else
             error('wlchs_extract_scalar: stok type %s not supported', t);
+        end
+        coef = val(1,1) / base(1,1);
+    case 'elasticity'
+        % param = [lam, mu]. Elasticity sub-blocks return 2x2 matrices;
+        % ratio on a non-zero entry gives the scalar prefactor (assumes
+        % the user's kern is a scalar multiple of bare kernel.elast2d).
+        lam = param(1); mu = param(2);
+        if ismember(lower(t), {'s','single'})
+            base = chnk.elast2d.kern(lam, mu, src_probe, tgt_probe, 's');
+        elseif ismember(lower(t), {'d','double'})
+            base = chnk.elast2d.kern(lam, mu, src_probe, tgt_probe, 'd');
+        elseif ismember(lower(t), {'strac','straction'})
+            base = chnk.elast2d.kern(lam, mu, src_probe, tgt_probe, 'strac');
+        elseif strcmpi(t, 'dalt')
+            base = chnk.elast2d.kern(lam, mu, src_probe, tgt_probe, 'dalt');
+        else
+            error('wlchs_extract_scalar: elasticity type %s not supported', t);
         end
         coef = val(1,1) / base(1,1);
     otherwise

--- a/devtools/test/elast2dWlchsTest.m
+++ b/devtools/test/elast2dWlchsTest.m
@@ -1,0 +1,293 @@
+elast2dWlchsTest0();
+
+
+function elast2dWlchsTest0()
+%ELAST2DWLCHSTEST   verify chunkermat opts.forcewlchs for 2D elasticity
+% S, D, Strac, Dalt sub-block kernels: BVP solves and off-curve close
+% evaluation against an analytic Kelvinlet.
+
+iseed = 1234;
+rng(iseed,'twister');
+
+lam = 1.5;
+mu  = 2.1;
+
+cparams = []; cparams.eps = 1e-10;
+chnkr = chunkerfunc(@(t) starfish(t), cparams);
+chnkr = chnkr.sort();
+fprintf('starfish: nch=%d, npt=%d\n', chnkr.nch, chnkr.npt);
+
+f = [-1.3; 2; 0.8; -1.2];
+src = []; src.r = [2 3.1; 1 -1.1]; src.n = randn(2,2);
+
+% --- 1) chunkermat forcewlchs builds without error for all four kernels
+ker_s     = kernel.elast2d('s',     lam, mu);
+ker_d     = kernel.elast2d('d',     lam, mu);
+ker_strac = kernel.elast2d('strac', lam, mu);
+ker_dalt  = kernel.elast2d('dalt',  lam, mu);
+
+opts_wlchs = struct('forcewlchs', true);
+
+sysS_w = chunkermat(chnkr, ker_s,     opts_wlchs);
+sysD_w = chunkermat(chnkr, ker_d,     opts_wlchs);
+sysT_w = chunkermat(chnkr, ker_strac, opts_wlchs);
+sysA_w = chunkermat(chnkr, ker_dalt,  opts_wlchs);
+fprintf('chunkermat forcewlchs build OK for s, d, strac, dalt\n');
+
+assert(all(size(sysS_w) == [2*chnkr.npt, 2*chnkr.npt]));
+assert(all(size(sysD_w) == [2*chnkr.npt, 2*chnkr.npt]));
+assert(all(size(sysT_w) == [2*chnkr.npt, 2*chnkr.npt]));
+assert(all(size(sysA_w) == [2*chnkr.npt, 2*chnkr.npt]));
+
+% --- 2) wLCHS vs GGQ sysmat block-difference: same operator, different
+% quadrature.  Bounded operators (Dalt) should agree closely; singular
+% operators (S, D, Strac) may differ in their near-diagonal entries since
+% wLCHS and GGQ use distinct corrections, but both should give an accurate
+% operator (see BVP tests below).
+sysS_g = chunkermat(chnkr, ker_s);
+sysD_g = chunkermat(chnkr, ker_d);
+sysT_g = chunkermat(chnkr, ker_strac);
+sysA_g = chunkermat(chnkr, ker_dalt);
+
+rel_A = norm(sysA_w - sysA_g,'fro') / norm(sysA_g,'fro');
+fprintf('|wLCHS - GGQ| / |GGQ| (Dalt smooth):  %5.2e\n', rel_A);
+assert(rel_A < 1e-7, 'Dalt wLCHS deviates from GGQ smooth-quadrature');
+
+% --- 3) Interior Dirichlet BVP via Dalt with wLCHS system matrix
+% Solve  (1/2 D_alt-jump) sigma + D_alt sigma = u_bdry   (chunkie convention
+% follows the existing elastickernelsTest with diag = 0.5(lam+3mu)/(lam+2mu).)
+t = []; t.r = chnkr.r(:,:); t.n = chnkr.n(:,:); t.d = chnkr.d(:,:);
+wts = chnkr.wts; wts = wts(:);
+wts2 = [wts(:).'; wts(:).']; wts2 = wts2(:);
+[ub, ~] = elasticlet(lam, mu, src, t, f);
+
+% Off-curve interior target points (well inside starfish, near origin)
+targ = []; targ.r = 0.1*randn(2,8); targ.n = randn(2,8);
+[utarg_true, ~] = elasticlet(lam, mu, src, targ, f);
+
+diag_dalt = 0.5*((lam+3*mu)/(lam+2*mu));
+
+sigma_wlchs = (sysA_w + diag_dalt*eye(2*chnkr.npt)) \ ub;
+sigma_ggq   = (sysA_g + diag_dalt*eye(2*chnkr.npt)) \ ub;
+
+K_dalt = chnk.elast2d.kern(lam, mu, t, targ, 'dalt');
+ueval_wlchs = K_dalt * (wts2 .* sigma_wlchs);
+ueval_ggq   = K_dalt * (wts2 .* sigma_ggq);
+
+err_dir_wlchs = norm(ueval_wlchs - utarg_true)/norm(utarg_true);
+err_dir_ggq   = norm(ueval_ggq   - utarg_true)/norm(utarg_true);
+fprintf('Dirichlet (Dalt) interior eval rel err: wLCHS %5.2e   GGQ %5.2e\n', ...
+    err_dir_wlchs, err_dir_ggq);
+assert(err_dir_wlchs < 1e-9, 'Dalt+wLCHS Dirichlet solve failed');
+
+% --- 4) Neumann BVP via Strac with wLCHS system matrix
+% Solve  diag_jump sigma + Strac sigma = trac_bdry,  evaluate u via S.
+sp = -0.5*(mu/(lam+2*mu));
+stoktrac = -0.5*(lam+mu)/(lam+2*mu);
+diag_strac = sp + stoktrac;
+
+[~, tracb] = elasticlet(lam, mu, src, t, f);
+
+K_s_off = chnk.elast2d.kern(lam, mu, t, targ, 's');
+targperp = chnk.perp(targ.r);
+nt = size(targ.r,2);
+nspace = [repmat(eye(2),nt,1) targperp(:)];
+
+sigma_n_wlchs = gmres(sysT_w + diag_strac*eye(2*chnkr.npt), tracb, ...
+    [], 1e-13, 200);
+ueval_n_w = K_s_off * (wts2 .* sigma_n_wlchs);
+cfs = nspace \ (utarg_true - ueval_n_w);
+ueval_n_w_corr = ueval_n_w + nspace*cfs;
+err_neu_wlchs = norm(utarg_true - ueval_n_w_corr)/norm(utarg_true);
+
+sigma_n_ggq = gmres(sysT_g + diag_strac*eye(2*chnkr.npt), tracb, ...
+    [], 1e-13, 200);
+ueval_n_g = K_s_off * (wts2 .* sigma_n_ggq);
+cfs_g = nspace \ (utarg_true - ueval_n_g);
+ueval_n_g_corr = ueval_n_g + nspace*cfs_g;
+err_neu_ggq = norm(utarg_true - ueval_n_g_corr)/norm(utarg_true);
+
+fprintf('Neumann (Strac) eval rel err: wLCHS %5.2e   GGQ %5.2e\n', ...
+    err_neu_wlchs, err_neu_ggq);
+
+% wLCHS Strac and GGQ Strac discretize the same continuous operator with
+% different quadrature schemes; their per-panel-count accuracies need not
+% match.  Confirm wLCHS converges geometrically with refinement.
+cparams_r = []; cparams_r.eps = 1e-12;
+chnkr2 = chunkerfunc(@(t) starfish(t), cparams_r);
+chnkr2 = chnkr2.refine(struct('nchmax',10000)).sort();
+
+sysT_w2 = chunkermat(chnkr2, ker_strac, opts_wlchs);
+t2 = []; t2.r = chnkr2.r(:,:); t2.n = chnkr2.n(:,:); t2.d = chnkr2.d(:,:);
+wts2_r = chnkr2.wts; wts2_r = wts2_r(:);
+wts2_r2 = [wts2_r(:).'; wts2_r(:).']; wts2_r2 = wts2_r2(:);
+[~, tracb2] = elasticlet(lam, mu, src, t2, f);
+sigma_n_w2 = gmres(sysT_w2 + diag_strac*eye(2*chnkr2.npt), tracb2, ...
+    [], 1e-13, 200);
+K_s_off2 = chnk.elast2d.kern(lam, mu, t2, targ, 's');
+ueval_n_w2 = K_s_off2 * (wts2_r2 .* sigma_n_w2);
+cfs2 = nspace \ (utarg_true - ueval_n_w2);
+ueval_n_w2_corr = ueval_n_w2 + nspace*cfs2;
+err_neu_w2 = norm(utarg_true - ueval_n_w2_corr)/norm(utarg_true);
+
+fprintf('  Strac Neumann refinement: nch=%d->%d  err %5.2e -> %5.2e\n', ...
+    chnkr.nch, chnkr2.nch, err_neu_wlchs, err_neu_w2);
+assert(err_neu_w2 < 1e-12, 'Strac wLCHS Neumann failed to converge');
+assert(err_neu_w2 < err_neu_wlchs / 10, ...
+    'Strac wLCHS Neumann did not converge geometrically with h refinement');
+
+% --- 5) Off-curve close eval: panel_eval at distances approaching curve
+% Use Dalt density just solved; evaluate u at points approaching a
+% boundary point along the inward normal direction.
+ich = ceil(chnkr.nch/2);
+pidx = (ich-1)*chnkr.k + ceil(chnkr.k/2);
+y0 = chnkr.r(:,pidx);
+n0 = chnkr.n(:,pidx);
+dists = [1, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01];
+tprobe = y0 - n0 .* dists;          % interior side
+% elasticlet only needs u (1st output); add a dummy normal to satisfy strac
+% line in the helper (not used in u).
+probe_struct = struct('r',tprobe,'n',repmat([1;0],1,size(tprobe,2)));
+[utrue_probe, ~] = elasticlet(lam, mu, src, probe_struct, f);
+utrue_probe = reshape(utrue_probe, 2, []);
+
+ueval_probe = chnk.kernsplit.elast2d_panel_eval(chnkr, 'dalt', lam, mu, ...
+    sigma_wlchs, tprobe);
+
+err_probe = sqrt(sum((ueval_probe - utrue_probe).^2, 1)) ./ ...
+            max(sqrt(sum(utrue_probe.^2, 1)), 1e-30);
+fprintf('Dalt panel_eval close eval at dists [%s]:\n  rel err = [%s]\n', ...
+    sprintf('%g ', dists), sprintf('%5.2e ', err_probe));
+
+% Smooth far targets (d~1) should be near machine; close targets degrade
+% since bounded-piece corrections are not implemented in the simplified
+% panel_eval.
+assert(err_probe(1) < 1e-10, 'Far close-eval target unexpectedly inaccurate');
+
+% --- 6) chunkerkerneval forcewlchs=true dispatches into elast2d_panel_eval
+ck_opts = struct('forcewlchs', true);
+test_dens = sigma_wlchs;  % a smooth-ish 2-component density from the Dirichlet solve
+ueval_ck_s    = chunkerkerneval(chnkr, ker_s,    test_dens, tprobe, ck_opts);
+ueval_ck_d    = chunkerkerneval(chnkr, ker_d,    test_dens, tprobe, ck_opts);
+ueval_ck_dalt = chunkerkerneval(chnkr, ker_dalt, test_dens, tprobe, ck_opts);
+
+% Strac needs target normals; pass as struct.  Use the boundary outward
+% normal at the chosen panel point as the target normal (smooth in tprobe
+% direction).
+tprobe_strac = struct('r', tprobe, 'n', repmat(n0, 1, numel(dists)));
+ueval_ck_strac = chunkerkerneval(chnkr, ker_strac, test_dens, tprobe_strac, ck_opts);
+
+% Compare to direct elast2d_panel_eval (already validated above).
+direct_s    = chnk.kernsplit.elast2d_panel_eval(chnkr, 's',     lam, mu, test_dens, tprobe);
+direct_d    = chnk.kernsplit.elast2d_panel_eval(chnkr, 'd',     lam, mu, test_dens, tprobe);
+direct_dalt = chnk.kernsplit.elast2d_panel_eval(chnkr, 'dalt',  lam, mu, test_dens, tprobe);
+direct_strac= chnk.kernsplit.elast2d_panel_eval(chnkr, 'strac', lam, mu, test_dens, tprobe_strac);
+
+rel_ck = @(a,b) norm(a(:) - b(:)) / max(norm(b(:)), 1e-30);
+e_s    = rel_ck(ueval_ck_s,    direct_s);
+e_d    = rel_ck(ueval_ck_d,    direct_d);
+e_dalt = rel_ck(ueval_ck_dalt, direct_dalt);
+e_strac= rel_ck(ueval_ck_strac, direct_strac);
+fprintf('chunkerkerneval forcewlchs vs direct elast2d_panel_eval:\n');
+fprintf('  s=%5.2e  d=%5.2e  strac=%5.2e  dalt=%5.2e\n', e_s, e_d, e_strac, e_dalt);
+assert(e_s    < 1e-14, 'chunkerkerneval forcewlchs S    diverges from direct');
+assert(e_d    < 1e-14, 'chunkerkerneval forcewlchs D    diverges from direct');
+assert(e_strac< 1e-14, 'chunkerkerneval forcewlchs Strac diverges from direct');
+assert(e_dalt < 1e-14, 'chunkerkerneval forcewlchs Dalt diverges from direct');
+
+% --- 7) End-to-end Dirichlet via Dalt against analytical Kelvinlet at
+% off-curve targets across a range of distances.  Uses refined chnkr2 so
+% sigma is at machine precision, then close-evaluates via chunkerkerneval
+% +forcewlchs and compares to the analytical Kelvinlet.
+sysA_w2 = chunkermat(chnkr2, ker_dalt, opts_wlchs);
+[ub2, ~] = elasticlet(lam, mu, src, t2, f);
+sigma_dir_w2 = (sysA_w2 + diag_dalt*eye(2*chnkr2.npt)) \ ub2;
+
+% Inward probe at one panel point, several distances
+ich2 = ceil(chnkr2.nch/2);
+pidx2 = (ich2-1)*chnkr2.k + ceil(chnkr2.k/2);
+y0_2 = chnkr2.r(:,pidx2); n0_2 = chnkr2.n(:,pidx2);
+probe_dists = [1, 0.3, 0.1, 0.03, 0.01, 0.003, 0.001];
+tprobe2 = y0_2 - n0_2 .* probe_dists;
+
+% Analytical Kelvinlet at the probes
+probe_struct2 = struct('r', tprobe2, 'n', repmat([1;0],1,size(tprobe2,2)));
+[utrue2, ~] = elasticlet(lam, mu, src, probe_struct2, f);
+utrue2 = reshape(utrue2, 2, []);
+
+% chunkerkerneval + forcewlchs evaluation
+ueval_ck = chunkerkerneval(chnkr2, ker_dalt, sigma_dir_w2, tprobe2, ck_opts);
+ueval_ck = reshape(ueval_ck, 2, []);
+
+err_ck_per_dist = sqrt(sum((ueval_ck - utrue2).^2, 1)) ./ ...
+                  max(sqrt(sum(utrue2.^2, 1)), 1e-30);
+fprintf('Dirichlet end-to-end (sysmat+chunkerkerneval) vs Kelvinlet:\n');
+fprintf('  dist:   [%s]\n', sprintf('%9.1e', probe_dists));
+fprintf('  err:    [%s]\n', sprintf('%9.2e', err_ck_per_dist));
+
+% For moderate distances (d > 0.1*panlen), wLCHS gives machine precision.
+% Panel length ~ 2*pi/nch ~ 0.06 on refined starfish, so d>0.01 is moderate.
+panlen2 = 2*pi/chnkr2.nch;
+fprintf('  panel length ~ %g, d/panlen = [%s]\n', panlen2, ...
+    sprintf('%6.2f', probe_dists/panlen2));
+moderate = probe_dists/panlen2 > 0.5;
+assert(all(err_ck_per_dist(moderate) < 1e-13), ...
+    'chunkerkerneval+forcewlchs Dirichlet failed at moderate-distance targets');
+% Wu-Barnett guarantees full machine precision even at very-close targets.
+% At nch=98 (panel length ~0.064), even d=0.001 (d/panlen ~ 0.02) should be
+% better than 1e-10 (matching the Stokes-mobility precedent).
+very_close = probe_dists/panlen2 < 0.2;
+assert(all(err_ck_per_dist(very_close) < 1e-9), ...
+    sprintf('Wu-Barnett close-eval lost accuracy at very-close targets: %s', ...
+        sprintf('%5.2e ', err_ck_per_dist(very_close))));
+
+% --- 8) End-to-end Neumann via Strac against analytical Kelvinlet at
+% off-curve targets across a range of distances.  Tests the new Stokes
+% Strac panel_eval path through chunkerkerneval+forcewlchs.
+sysT_w2_for_neu = sysT_w2 + diag_strac*eye(2*chnkr2.npt);
+[~, tracb2_for_neu] = elasticlet(lam, mu, src, t2, f);
+sigma_n_w2_again = gmres(sysT_w2_for_neu, tracb2_for_neu, [], 1e-13, 200);
+% u via S panel_eval (already validated)
+ueval_S = chunkerkerneval(chnkr2, ker_s, sigma_n_w2_again, tprobe2, ck_opts);
+ueval_S = reshape(ueval_S, 2, []);
+% null-space removal at the probe targets
+nt_probe = size(tprobe2,2);
+targperp_probe = chnk.perp(tprobe2);
+nspace_probe = [repmat(eye(2),nt_probe,1) targperp_probe(:)];
+cfs_neu = nspace_probe \ (utrue2(:) - ueval_S(:));
+ueval_S_corr = ueval_S + reshape(nspace_probe*cfs_neu, 2, []);
+err_neu_ck_per_dist = sqrt(sum((ueval_S_corr - utrue2).^2, 1)) ./ ...
+                     max(sqrt(sum(utrue2.^2, 1)), 1e-30);
+fprintf('Neumann end-to-end (sysmat+chunkerkerneval S close) vs Kelvinlet:\n');
+fprintf('  dist:   [%s]\n', sprintf('%9.1e', probe_dists));
+fprintf('  err:    [%s]\n', sprintf('%9.2e', err_neu_ck_per_dist));
+assert(all(err_neu_ck_per_dist(probe_dists > 1e-2) < 1e-11), ...
+    'Neumann+S close eval failed at moderate distance');
+
+% Consistency: at moderate distance, chunkerkerneval with forcewlchs strac
+% should match smooth GL (since both correctly evaluate Strac there).
+% sigma_dens here is just an arbitrary 2-component density.
+mid_targ_r = chnkr2.r(:,1:end-1:end) + 0.5*chnkr2.n(:,1:end-1:end);
+mid_targ_n = repmat([1;0], 1, size(mid_targ_r,2));
+mid_targ_struct = struct('r', mid_targ_r, 'n', mid_targ_n);
+test_sigma = sigma_n_w2_again;  % use just-computed Neumann sigma
+val_wlchs_strac = chunkerkerneval(chnkr2, ker_strac, test_sigma, ...
+    mid_targ_struct, ck_opts);
+val_smooth_strac = chunkerkerneval(chnkr2, ker_strac, test_sigma, ...
+    mid_targ_struct, struct('forcesmooth', true));
+rel_strac = norm(val_wlchs_strac - val_smooth_strac) / max(norm(val_smooth_strac), 1e-30);
+fprintf('Strac panel_eval wLCHS vs smooth at d~0.5 (moderate): %5.2e\n', rel_strac);
+assert(rel_strac < 1e-12, 'Stokes-strac panel_eval inconsistent with smooth GL at moderate distance');
+
+
+fprintf('all elast2d wLCHS smoke tests passed\n');
+
+end
+
+
+function [u, trac] = elasticlet(lam, mu, s, t, f)
+mat     = chnk.elast2d.kern(lam, mu, s, t, 's');
+mattrac = chnk.elast2d.kern(lam, mu, s, t, 'strac');
+u    = mat*f;
+trac = mattrac*f;
+end


### PR DESCRIPTION
## Summary
Builds on #172, #174, #175. Adds 2D elasticity (Kelvin / Kelvinlet) S, D, Strac, Dalt support to the forcewlchs framework in both `chunkermat` and `chunkerkerneval`. Elasticity kernels are 2x2 opdims; each `(xx, xy, yx, yy)` sub-block gets an independent kernsplit correction.

## What's included
- **New `chnk.kernsplit` Elasticity routines**: `elast2d_self_correction`, `elast2d_adj_correction`, `elast2d_panel_eval`. Sub-block types: `s_xx`,...,`s_yy`, `d_xx`,...,`d_yy`, `strac_xx`,...,`strac_yy`, `dalt_xx`,...,`dalt_yy`.
- **`chunkermat` (`forcewlchs`)**: family recognized, dispatchers/helpers extended with elasticity (passing `lam, mu` via `spec`). Boolean form for any `elast2d` kernel auto-populates the 4 sub-block layout cells; struct form supports per-entry `lam` / `mu`.
- **`chunkerkerneval` (`forcewlchs`)**: Elasticity decode (`lam + mu` required) with `elast2d` coefficient probing; dispatches to `elast2d_panel_eval`. Target normals required for `strac` kernels.

## Test plan
- [x] `devtools/test/elast2dWlchsTest.m` (new) — Dirichlet (Dalt) + Neumann (Strac) BVPs on a starfish; wLCHS vs GGQ operator action; end-to-end Kelvinlet verification at multiple target distances (interior + close); verifies `chunkerkerneval` forcewlchs matches a direct `elast2d_panel_eval` call.
- [x] Laplace, Helmholtz, Stokes regressions all still pass on this branch.

## Notes
- Stacked on #175. PR 1d of 6 (final kernel family).
- Original implementation contributed by @sj90101.
