### PR TITLE
Add cavity curver and chunker mean

### DIFF
--- a/chunkie/+chnk/+curves/cavity.m
+++ b/chunkie/+chnk/+curves/cavity.m
@@ -1,0 +1,79 @@
+function [r,d,d2] = cavity(t,varargin)
+%CHNK.CURVES.CAVITY return position, first and second derivatives of a
+% cavity-shaped domain, given by a radially-deformed ellipse in polar
+% coordinates
+%
+% Syntax: [r,d,d2] = chnk.curves.cavity(t,j)
+%
+% Input:
+%   t - array of points (in [0,2*pi])
+%
+% Optional input:
+%   j - real number, controls eccentricity and "depth" of the cavity.
+%       should satisfy 0 <= j <~ 11.12 to avoid self-intersection
+%       (default 10)
+%
+% Output:
+%   r - 2 x numel(t) array of positions, r(:,i) = [x(t(i)); y(t(i))]
+%   d - 2 x numel(t) array of t derivative of r
+%   d2 - 2 x numel(t) array of second t derivative of r
+%
+% Examples:
+%   [r,d,d2] = chnk.curves.cavity(t); % get default settings
+%   [r,d,d2] = chnk.curves.cavity(t,j); % change j
+
+j = 10;
+if nargin > 1 && ~isempty(varargin{1})
+    j = varargin{1};
+end
+
+if j > 11
+    warning('chnk.curves.cavity:selfintersect', ...
+        'cavity curve may self intersect for j > 11');
+end
+
+rx = (1-(j-1)/11)+0.03*(j-1);
+ry = (1-(j-1)/11)+0.8*(j-1);
+
+ct = cos(t);
+st = sin(t);
+
+xt = rx*ct + 20;
+dxdt = -rx*st;
+d2xdt2 = -rx*ct;
+yt = ry*st;
+dydt = ry*ct;
+d2ydt2 = -ry*st;
+
+rmax = 400*rx*rx/(ry*ry-rx*rx) + 400 + ry^2;
+
+a = (1+ 0.7*(j-1))/2;
+C = 1/rmax^a;
+rho_t = C*(xt.^2 + yt.^2).^(a);
+drho_t_dt = 2*C*a*(xt.^2 + yt.^2).^(a-1).*(xt.*dxdt + yt.*dydt);
+d2rho_t_dt2 = C*((a-1)*a*(xt.^2+yt.^2).^(a-2).*(2*xt.*dxdt + 2*yt.*dydt).^2 + ...
+     a*(xt.*xt + yt.*yt).^(a-1).*(2*xt.*d2xdt2 + 2*dxdt.*dxdt + 2*yt.*d2ydt2 + 2*dydt.*dydt));
+
+rfac = 2*a;
+theta_t = rfac*atan2(yt,xt);
+dtheta_t_dt = rfac*(xt.*dydt - yt.*dxdt)./(xt.*xt + yt.*yt);
+d2theta_t_dt2 = rfac*(xt.*yt.*(2*dxdt.*dxdt + yt.*d2ydt2 -2*dydt.*dydt) - ...
+        xt.*xt.*(yt.*d2xdt2 + 2*dxdt.*dydt) + ...
+         yt.*yt.*(2*dxdt.*dydt - yt.*d2xdt2) + xt.*xt.*xt.*d2ydt2)./ ...
+     (xt.*xt + yt.*yt).^2;
+
+xs = rho_t.*cos(theta_t);
+ys = rho_t.*sin(theta_t);
+dxs = drho_t_dt.*cos(theta_t) - rho_t.*sin(theta_t).*dtheta_t_dt;
+dys = drho_t_dt.*sin(theta_t) + rho_t.*cos(theta_t).*dtheta_t_dt;
+
+d2xs = d2rho_t_dt2.*cos(theta_t) - 2*drho_t_dt.*sin(theta_t).*dtheta_t_dt -...
+          rho_t.*(cos(theta_t).*dtheta_t_dt.^2 + sin(theta_t).*d2theta_t_dt2);
+d2ys = d2rho_t_dt2.*sin(theta_t) + 2*drho_t_dt.*cos(theta_t).*dtheta_t_dt +...
+          rho_t.*(-sin(theta_t).*dtheta_t_dt.^2 + cos(theta_t).*d2theta_t_dt2);
+
+r = [(xs(:)).'; (ys(:)).'];
+d = [(dxs(:)).'; (dys(:)).'];
+d2 = [(d2xs(:)).'; (d2ys(:)).'];
+
+end

--- a/chunkie/@chunker/chunker.m
+++ b/chunkie/@chunker/chunker.m
@@ -43,6 +43,8 @@ classdef chunker
 %   obj = reverse(obj) - reverse chunk orientation
 %   rmin = min(obj) - minimum of coordinate values
 %   rmax = max(obj) - maximum of coordinate values
+%   rmean = mean(obj) - weighted average of coordinate values
+%   rctr = ctr(obj) - average of max(obj) and min(obj)
 %   wts = weights(obj) - scaled integration weights on curve
 %   obj.n = normals(obj) - recompute normal vectors
 %   onesmat = onesmat(obj) - matrix that corresponds to integration of a
@@ -353,6 +355,8 @@ classdef chunker
         obj = move(obj,r0,r1,trotat,scale)
         rmin = min(obj)
         rmax = max(obj)
+        rmean = mean(obj)
+        rctr = ctr(obj)
         whts = whts(obj)
         wts = weights(obj)
         rnorm = normals(obj)

--- a/chunkie/@chunker/ctr.m
+++ b/chunkie/@chunker/ctr.m
@@ -1,0 +1,20 @@
+function rctr = ctr(obj)
+%CTR center of chunker object
+%
+% This is the average of chnkr.max and chnkr.min
+%
+% Syntax: rctr = ctr(chnkr)
+%
+% Input:
+%   chnkr - chunker object
+%
+% Output:
+%   rctr - chnkr.dim length vector, average of max and min of chnkr
+%
+% Examples:
+%   rctr = ctr(chnkr);
+%
+
+% author: Tristan Goodwill
+
+rctr = (max(obj) + min(obj))/2;

--- a/chunkie/@chunker/mean.m
+++ b/chunkie/@chunker/mean.m
@@ -1,0 +1,24 @@
+function rmean = mean(obj)
+%MEAN weighted average position over chunker nodes
+%
+% This is the average of chnkr.r weighted by the integration weights,
+% i.e. an approximation to the average position of the curve
+%
+% Syntax: rmean = mean(chnkr)
+%
+% Input:
+%   chnkr - chunker object
+%
+% Output:
+%   rmean - chnkr.dim length vector, weighted average of node positions
+%
+% Examples:
+%   rmean = mean(chnkr);
+%
+
+% author: Tristan Goodwill
+
+rs = reshape(real(obj.r),obj.dim,obj.k*obj.nch);
+wts = obj.wts(:).';
+
+rmean = sum(rs.*wts,2)/sum(wts);

--- a/chunkie/@chunkgraph/chunkgraph.m
+++ b/chunkie/@chunkgraph/chunkgraph.m
@@ -69,6 +69,8 @@ classdef chunkgraph
 %      a meshgrid of points that are close to the chunkgraph
 %   rmin = min(obj) - minimum of coordinate values
 %   rmax = max(obj) - maximum of coordinate values
+%   rmean = mean(obj) - weighted average of coordinate values
+%   rctr = ctr(obj) - average of max(obj) and min(obj)
 %   onesmat = onesmat(obj) - matrix that corresponds to integration of a
 %             density on the chunkgraph
 %   rnormonesmat = normonesmat(obj) - matrix that corresponds to
@@ -445,6 +447,8 @@ classdef chunkgraph
         obj = move(obj, r0, r1, trotat, scale)
         rmin = min(obj)
         rmax = max(obj)
+        rmean = mean(obj)
+        rctr = ctr(obj)
         plot(obj, varargin)
         quiver(obj, varargin)
         plot_regions(obj, iflabel)

--- a/chunkie/@chunkgraph/ctr.m
+++ b/chunkie/@chunkgraph/ctr.m
@@ -1,0 +1,20 @@
+function rctr = ctr(obj)
+%CTR center of chunkgraph object
+%
+% This is the average of cgrph.max and cgrph.min
+%
+% Syntax: rctr = ctr(cgrph)
+%
+% Input:
+%   chnkr - chunkgraph object
+%
+% Output:
+%   rctr - chnkr.dim length vector, average of max and min of chnkr
+%
+% Examples:
+%   rctr = ctr(cgrph);
+%
+
+% author: Tristan Goodwill
+
+rctr = (max(obj) + min(obj))/2;

--- a/chunkie/@chunkgraph/mean.m
+++ b/chunkie/@chunkgraph/mean.m
@@ -1,0 +1,24 @@
+function rmean = mean(obj)
+%MEAN weighted average position over chunkgraph nodes
+%
+% This is the average of cgrph.r weighted by the integration weights,
+% i.e. an approximation to the average position of the curve
+%
+% Syntax: rmean = mean(cgrph)
+%
+% Input:
+%   chnkr - chunkgraph object
+%
+% Output:
+%   rmean - cgrph.dim length vector, weighted average of node positions
+%
+% Examples:
+%   rmean = mean(cgrph);
+%
+
+% author: Tristan Goodwill
+
+rs = reshape(real(obj.r),obj.dim,obj.npt);
+wts = obj.wts(:).';
+
+rmean = sum(rs.*wts,2)/sum(wts);

--- a/devtools/test/chunkerfuncTest.m
+++ b/devtools/test/chunkerfuncTest.m
@@ -89,7 +89,29 @@ chnkr = refine(chnkr,struct('nover',1));
 a = area(chnkr);
 assert(abs(a - pi*r^2) < 1e-12,'area wrong for circle domain')
 
-% iflcosed flag testing 
+% chunk up cavity geometry
+
+cparams = []; cparams.eps = 1.0e-4;
+start = tic; chnkr = chunkerfunc(@(t) chnk.curves.cavity(t,11),cparams,pref);
+t1 = toc(start);
+
+fprintf('%5.2e seconds to chunk cavity domain with %d chunks\n', ...
+    t1,chnkr.nch);
+
+[~,~,info] = sortinfo(chnkr);
+assert(info.ier == 0,'adjacency issues after chunk build cavity');
+
+% test mean and ctr on cavity chunker
+
+rmean = mean(chnkr);
+rmean2 = sum(chnkr.r(:,:).*chnkr.wts(:).',2)/sum(chnkr.wts(:));
+assert(norm(rmean-rmean2) < 1e-12,'mean does not match definition');
+
+rctr = chnkr.ctr;
+rctr2 = (max(chnkr)+min(chnkr))/2;
+assert(norm(rctr-rctr2) < 1e-12,'ctr does not match definition');
+
+% iflcosed flag testing
 
 lastwarn(''); %clears warning state
 cparams = [];

--- a/devtools/test/chunkgraph_basicTest.m
+++ b/devtools/test/chunkgraph_basicTest.m
@@ -40,6 +40,16 @@ assert(nnz(cgrph1.v2emat-cgrph2.v2emat) == 0);
 
 cgrph1 = balance(cgrph1);
 
+% test mean and ctr on pentagonal chunkgraph
+
+rmean = mean(cgrph1);
+rmean2 = sum(cgrph1.r(:,:).*cgrph1.wts(:).',2)/sum(cgrph1.wts(:));
+assert(norm(rmean-rmean2) < 1e-12,'mean does not match definition');
+
+rctr = ctr(cgrph1);
+rctr2 = (max(cgrph1)+min(cgrph1))/2;
+assert(norm(rctr-rctr2) < 1e-12,'ctr does not match definition');
+
 % a graph with two edges in the old format
 
 verts = [1 0 1; -1 0 1]; edge2verts = [-1 1 0; 0 -1 1];


### PR DESCRIPTION
Add the Charlie cavity as an example curve.

Also add option to compute the centre of chunkers and chunkgraphs by average extend or the weighted average. We may not need both.