### PR TITLE
adding data to chunkgraphs and RCIP

### DIFF
--- a/chunkie/+chnk/+rcip/Rcompchunk.m
+++ b/chunkie/+chnk/+rcip/Rcompchunk.m
@@ -94,8 +94,15 @@ dscal = zeros(nedge,1);
 d2scal = zeros(nedge,1);
 ctr = zeros(dim,nedge);
 
+if max([chnkr.datadim]) > 0
+datacs = zeros(k,max([chnkr.datadim]),nedge);
+end
+
 ileftright = zeros(nedge,1);
 nextchunk = zeros(nedge,1);
+
+% flag for whether the edges meeting at this vertex carry data
+hasdata = false(nedge,1);
 
 for i = 1:nedge
     ic = iedgechunks(1,i);
@@ -106,6 +113,10 @@ for i = 1:nedge
     d2 = chnkri.d2(:,:,ie);    
     il = chnkri.adj(1,ie);
     ir = chnkri.adj(2,ie);
+    hasdata(i) = chnkri.hasdata;
+    if hasdata(i)
+        datai = chnkri.data(:,:,ie);
+    end
     if (il > 0 && ir < 0)
         nextchunk(i) = il;
         ileftright(i) = 1;
@@ -116,7 +127,10 @@ for i = 1:nedge
         dcs(:,:,i) = u*(d.');
         d2cs(:,:,i) = u*(d2.');
         dscal(i) = 2;
-        d2scal(i) = 4; 
+        d2scal(i) = 4;
+        if hasdata(i)
+            datacs(:,1:chnkri.datadim,i) = u*(datai.');
+        end
     elseif (il < 0 && ir > 0)
         nextchunk(i) = ir;
         ileftright(i) = -1;
@@ -126,7 +140,10 @@ for i = 1:nedge
         dcs(:,:,i) = u*(d.');
         d2cs(:,:,i) = u*(d2.');
         dscal(i) = 2;
-        d2scal(i) = 4; 
+        d2scal(i) = 4;
+        if hasdata(i)
+            datacs(:,1:chnkri.datadim,i) = u*(datai.');
+        end
     else
         error('RCIP: edge chunk not adjacent to one vertex and one neighbor')
     end
@@ -141,6 +158,10 @@ rcipsav.d2scal = d2scal;
 rcipsav.ileftright = ileftright;
 rcipsav.glxs = glxs;
 rcipsav.glws = glws;
+
+if max([chnkr.datadim]) > 0
+rcipsav.datacs = datacs;
+end
 
 pref = []; 
 pref.k = k;
@@ -214,6 +235,10 @@ for level=1:nsub
     for i=1:nedge
         chnkrlocal(i) = chnk.rcip.chunkerfunclocal(@(t) shiftedcurve(t,rcs(:,:,i),dcs(:,:,i), ...
             dscal(i),d2cs(:,:,i),d2scal(i),ileftright(i)),ts{i},pref,glxs,glws);
+        if hasdata(i)
+            chnkrlocal(i) = setdatalocal(chnkrlocal(i),ts{i},datacs(:,:,i), ...
+                ileftright(i),glxs);
+        end
     end
     
     % at the top level, append/prepend the next chunk
@@ -226,6 +251,13 @@ for level=1:nsub
             chnkrlocal(i).r(:,:,nchi+1) = chnkr(ic).r(:,:,nc)-ctr(:,i);
             chnkrlocal(i).d(:,:,nchi+1) = chnkr(ic).d(:,:,nc);                
             chnkrlocal(i).d2(:,:,nchi+1) = chnkr(ic).d2(:,:,nc); 
+
+            if hasdata(i)
+                if ~chnkrlocal(i).hasdata
+                    chnkrlocal(i) = chnkrlocal(i).makedatarows(size(chnkr(ic).data,1));
+                end
+                chnkrlocal(i).data(:,:,nchi+1) = chnkr(ic).data(:,:,nc);
+            end
 
             if ileftright(i) == -1
                 chnkrlocal(i).adj(1,nchi+1) = nchi;
@@ -288,6 +320,39 @@ pols = lege.pols(tt,nm1); pols = pols.';
 r = (t.*(pols(:,1:nm1)*rc)).';
 d = (scald*(pols*dc)).';
 d2 = (scald2*(pols*d2c)).';
+
+end
+
+function chnkr = setdatalocal(chnkr,ts,datac,ilr,xs)
+%SETDATALOCAL set data on a local chunker, mirroring shiftedcurve's
+% Legendre expansion for d/d2 (plain expansion, no vanishing-at-corner
+% factor, since data need not vanish at the vertex like r does)
+
+datadim = size(datac,2);
+nch = chnkr.nch;
+k = chnkr.k;
+nm1 = k-1;
+
+chnkr = chnkr.makedatarows(datadim);
+
+ab = zeros(2,nch);
+ab(1,:) = ts(1:end-1);
+ab(2,:) = ts(2:end);
+
+for i = 1:nch
+    a = ab(1,i);
+    b = ab(2,i);
+    tt = a + (b-a)*(xs+1)/2;
+
+    if (ilr == -1)
+        ttshift = 2*tt-1;
+    else
+        ttshift = 2*tt+1;
+    end
+    pols = lege.pols(ttshift,nm1); pols = pols.';
+
+    chnkr.data(:,:,i) = (pols*datac).';
+end
 
 end
 

--- a/chunkie/@chunker/arclengthder.m
+++ b/chunkie/@chunker/arclengthder.m
@@ -19,7 +19,12 @@ function du = arclengthder(chnkr,u)
 %
 
 dmat = lege.dermat(chnkr.k);
-ds = squeeze(sqrt(chnkr.d(1,:,:).^2+chnkr.d(2,:,:).^2));
+
+if chnkr.dim == 2
+    ds = squeeze(sqrt(chnkr.d(1,:,:).^2+chnkr.d(2,:,:).^2));
+elseif chnkr.dim == 3 
+    ds = squeeze(sqrt(chnkr.d(1,:,:).^2+chnkr.d(2,:,:).^2+chnkr.d(3,:,:).^2));
+end
 
 du = dmat*reshape(u,[chnkr.k chnkr.nch]);
 du = du ./ ds;

--- a/chunkie/@chunker/chunker.m
+++ b/chunkie/@chunker/chunker.m
@@ -70,6 +70,8 @@ classdef chunker
 %   [re,taue] = chunkends(obj,ich) - get the endpoints of chunks
 %   flag = flagnear(obj,pts,opts) - flag points near the boundary
 %   obj = obj.move(r0,r1,trotat,scale) - translate, rotate, etc
+%   du = arclengthder(chnkr,u) - returns arclength derivative of u along
+%              the boundary of the chunker
 
 
 % author: Travis Askham (askhamwhat@gmail.com)

--- a/chunkie/@chunkgraph/arclengthder.m
+++ b/chunkie/@chunkgraph/arclengthder.m
@@ -1,0 +1,32 @@
+function du = arclengthder(cgrph,u)
+%ARCLENGTHDER arc length derivative of function on chunkgraph
+%
+% Calculates the arclength derivative of u using Gauss-Legendre 
+%   spectral differentiation matrix. The derivative on the ith chunk is 
+%   given by du(:,i) where du is the output of this routine
+%
+% Syntax: du = arclengthder(cgrph,u)
+%
+% Input:
+%   cgrph - chunkgraph object
+%   u - function or density defined on cgrph
+%
+% Output:
+%   du - arclength derivative of u
+%
+% Examples:
+%   du = arclengthder(cgrph,u);
+%
+
+dmat = lege.dermat(cgrph.k);
+
+if cgrph.dim == 2
+    ds = squeeze(sqrt(cgrph.d(1,:,:).^2+cgrph.d(2,:,:).^2));
+elseif cgrph.dim == 3 
+    ds = squeeze(sqrt(cgrph.d(1,:,:).^2+cgrph.d(2,:,:).^2+cgrph.d(3,:,:).^2));
+end
+
+du = dmat*reshape(u,[cgrph.k cgrph.nch]);
+du = du ./ ds;
+
+end

--- a/chunkie/@chunkgraph/chunkgraph.m
+++ b/chunkie/@chunkgraph/chunkgraph.m
@@ -32,7 +32,7 @@ classdef chunkgraph
 %   k - integer, number of Legendre nodes on each chunk
 %   dim - integer, dimension of the ambient space in which the curve is 
 %             embedded
-%   In the rest, nch = \sum_{j} chunkgraph.echnks(j).nch;
+%   nch - integer, total number of chunks in the chunkgraph
 %   npt - returns k*nch, the total number of points on the curve
 %   r - dim x k x nch array, r(:,i,j) gives the coordinates of the ith 
 %         node on the jth chunk of the chunkgraph
@@ -80,6 +80,8 @@ classdef chunkgraph
 %   rflag = datares(obj,opts) - check if data in data rows is resolved
 %   edge_reg = find_regions_of_edges(obj) - determine regions on either 
 %                side of each edge
+%   du = arclengthder(cgrph,u) - returns arclength derivative of u along
+%              the boundary of the chunkgraph
 %
 % Syntax:
 %
@@ -139,6 +141,7 @@ classdef chunkgraph
         k
         dim
         datadim
+        nch
     end
 
     properties(SetAccess=private)
@@ -425,6 +428,9 @@ classdef chunkgraph
         function dim = get.dim(obj)
             dim = size(obj.r,1);
         end
+        function nch = get.nch(obj)
+            nch = size(obj.r,3);
+        end        
         function datadim = get.datadim(obj)
             datadim = size(obj.data,1);
         end
@@ -472,7 +478,8 @@ classdef chunkgraph
         obj = plus(v,obj)
         obj = mtimes(A,obj)        
         obj = rotate(obj,theta,r0,r1)
-        obj = reflect(obj,theta,r0,r1)   
+        obj = reflect(obj,theta,r0,r1)  
+        du = arclengthder(obj,u)        
         err = chunk_fun_error(obj,fval)
     end
 

--- a/chunkie/@chunkgraph/chunkgraph.m
+++ b/chunkie/@chunkgraph/chunkgraph.m
@@ -140,7 +140,11 @@ classdef chunkgraph
         dim
         datadim
     end
-    
+
+    properties(SetAccess=private)
+        nedge
+    end
+
     methods
         function obj = chunkgraph(verts, edgesendverts, fchnks, cparams, pref)
             %CHUNKGRAPH constructor. Documented above.
@@ -173,6 +177,7 @@ classdef chunkgraph
             obj.edgesendverts = edgesendverts;
             obj.v2emat        = build_v2emat(obj);
             obj.echnks        = chunker.empty;
+            obj.nedge         = nedge;
 
             if nargin < 3
                 fchnks = [];
@@ -372,6 +377,12 @@ classdef chunkgraph
         end  
         function obj = set.wts(obj,val)
             obj.wts = val;
+        end
+        function obj = set.data(obj,val)
+            nptvec = [obj.echnks.npt];
+            for ii = 1:length(obj.echnks)
+                obj.echnks(ii).data(:,:) = val(:,sum(nptvec(1:ii-1))+1:sum(nptvec(1:ii)));
+            end
         end
         function r = get.r(obj)
             chnk = merge(obj.echnks);

--- a/chunkie/@chunkgraph/makedatarows.m
+++ b/chunkie/@chunkgraph/makedatarows.m
@@ -14,12 +14,9 @@ function obj = makedatarows(obj,nrows)
 %
 %
     if (nrows > 0)
-        datatemp = obj.data;
-        datadimold = obj.datadim;
-        nch = sum(horzcat(obj.echnks.nch));
-        obj.data = zeros(datadimold+nrows,obj.k,nch);
-        obj.data(1:datadimold,:) = datatemp(:,:);
-        obj.hasdata = true;
+        for ii = 1:length(obj.echnks)
+            obj.echnks(ii) = makedatarows(obj.echnks(ii),nrows);
+        end
     else
         if (nrows < 0)
             warning('attempted to add negative rows, doing nothing');

--- a/devtools/test/chunkgraphrcipDataImpedanceTest.m
+++ b/devtools/test/chunkgraphrcipDataImpedanceTest.m
@@ -50,6 +50,7 @@ t1 = toc(t0);
 fprintf('%5.2e s : time to build geo\n',t1)
 
 fprintf('Number of points: %d\n',cgrph.npt)
+fprintf('Number of chunks: %d\n',cgrph.nch)
 fprintf('Number of edges: %d\n',cgrph.nedge)
 
 zk = 1.1;

--- a/devtools/test/chunkgraphrcipDataImpedanceTest.m
+++ b/devtools/test/chunkgraphrcipDataImpedanceTest.m
@@ -1,0 +1,160 @@
+chunkgraphrcip_Data_Impedance_Test();
+
+
+function chunkgraphrcip_Data_Impedance_Test()
+
+%CHUNKGRAPHRCIP_DATA_IMPEDANCE_TEST
+%
+% Solving the interior Helmholtz problem with impedance BCs:
+%
+%       alpha(x) du/dn + i beta(x) u = 0 , 
+%
+% where alpha and beta are allowed to vary along the boundary. We solve
+% this problem using the following scaled Laplace single layer ansatz: 
+%   
+%           u = 2 \int G(x,y) \mu(y) / alpha(y) ds(y) , 
+% 
+% where G(x,y) is the Helmholtz Green's function and alpha is bounded 
+% below by a positive number.
+%
+% This problem is solved on a square chunkgraph where alpha and beta are 
+% stored as chunkgraph data. This test checks whether chunkgraph data
+% is properly added and stored and whether RCIP is properly interpolating 
+% source and target data.
+
+rng(1);
+
+t0 = tic;
+vertsq = [1 1 -1 -1; -1 1 1 -1];
+edges = [1 2 3 4; 2 3 4 1];
+
+cparams = [];
+cparams.eps = 1.0e-10;
+[cgrph] = chunkgraph(vertsq,edges,[],cparams);
+
+cgrph = makedatarows(cgrph,2);
+
+% Impedance coefficients, chosen arbitrarily
+cgrph.data(1,:) = [cgrph.echnks(1).r(2,:).^2+2, ...
+    cgrph.echnks(2).r(1,:).^2+2, ...
+    cgrph.echnks(3).r(2,:).^2+2, ...
+    cgrph.echnks(4).r(1,:).^2+2];  % alpha 
+
+cgrph.data(2,:) = [cgrph.echnks(1).r(1,:), ...
+    cgrph.echnks(2).r(2,:)+2, ...
+    cgrph.echnks(3).r(2,:)-2, ...
+    cgrph.echnks(4).r(1,:).^2]; % beta
+
+t1 = toc(t0);
+
+fprintf('%5.2e s : time to build geo\n',t1)
+
+fprintf('Number of points: %d\n',cgrph.npt)
+fprintf('Number of edges: %d\n',cgrph.nedge)
+
+zk = 1.1;
+
+% sources
+
+sources = [[-2.3;0],[1.6;1],[3.1;-0.7]];
+strengths = rand(size(sources,2),1);
+
+% targets
+
+nt = 3;
+ts = 0.0+2*pi*rand(nt,1);
+targets = 2*rand(2,nt)-1;
+
+% plot geo and sources
+
+xs = cgrph.r(1,:,:); xmin = min(xs(:)); xmax = max(xs(:));
+ys = cgrph.r(2,:,:); ymin = min(ys(:)); ymax = max(ys(:));
+
+figure(1)
+clf
+hold off
+plot(cgrph)
+hold on
+scatter(sources(1,:),sources(2,:),'o')
+scatter(targets(1,:),targets(2,:),'x')
+axis equal 
+
+%
+
+kern = @(s,t) kerntot(s,t,zk);
+kerns = @(s,t) 2*chnk.helm2d.kern(zk,s,t,'s');
+kernsp = @(s,t) 2*chnk.helm2d.kern(zk,s,t,'sp');
+kernrep = @(s,t) 2*chnk.helm2d.kern(zk,s,t,'s') ./ s.data(1,:);
+
+% eval u on bdry
+
+srcinfo = []; srcinfo.r = sources; 
+targinfo = []; targinfo.r = cgrph.r; targinfo.n = cgrph.n; targinfo.data = cgrph.data;
+kernmats = cgrph.data(1,:).'.*kernsp(srcinfo,targinfo) ...
+    + 1i*cgrph.data(2,:).'.*kerns(srcinfo,targinfo);
+ubdry = kernmats*strengths;
+
+% eval u at targets
+
+targinfo = []; targinfo.r = targets;
+kernmatstarg = kerns(srcinfo,targinfo);
+utarg = kernmatstarg*strengths;
+
+%
+
+% build laplace dirichlet matrix
+
+opts = []; opts.rcip = true; opts.sing = 'log'; opts.nsub_or_tol = 40;
+start = tic; 
+A = chunkermat(cgrph,kern,opts);
+t1 = toc(start);
+
+fprintf('%5.2e s : time to assemble matrix\n',t1)
+
+sys = eye(cgrph.npt) + A;
+
+rhs = ubdry; rhs = rhs(:);
+start = tic; sol = gmres(sys,rhs,[],1e-14,100); t1 = toc(start);
+
+fprintf('%5.2e s : time for dense gmres\n',t1)
+
+start = tic; sol2 = sys\rhs; t1 = toc(start);
+
+fprintf('%5.2e s : time for dense backslash solve\n',t1)
+
+err = norm(sol-sol2,'fro')/norm(sol2,'fro');
+
+fprintf('difference between direct and iterative %5.2e\n',err)
+
+% evaluate at targets and compare
+
+opts = [];
+start=tic; Dsol = chunkerkerneval(cgrph,kernrep,sol2,targets,opts); 
+t1 = toc(start);
+fprintf('%5.2e s : time to eval at targs (slow, adaptive routine)\n',t1)
+
+%
+
+wcgrph = cgrph.wts;
+
+relerr = norm(utarg-Dsol,'fro')/norm(utarg,'fro');
+relerr2 = norm(utarg-Dsol,'inf')/dot(abs(sol(:)),wcgrph(:));
+fprintf('relative frobenius error %5.2e\n',relerr);
+fprintf('relative l_inf/l_1 error %5.2e\n',relerr2);
+
+assert(relerr < 1e-10);
+
+end
+
+
+function val = kerntot(s,t,zk)
+
+alphas = s.data(1,:);
+alphat = t.data(1,:);
+
+beta = t.data(2,:);
+
+val = 2*alphat(:).*chnk.helm2d.kern(zk,s,t,'sp') ./ alphas ...
+    + 2i*beta(:).*chnk.helm2d.kern(zk,s,t,'s') ./ alphas;
+
+end


### PR DESCRIPTION
Fixed chunkgraph makedatarows to loop over chunks and add data rows to each one. Also added a data setter to the chunkgraph class which does the same. RCIP previously did not do anything involving data, so I added datacs to Rcompchunk and set local data on local chnkrs during RCIP. Also added an nedge property to chunkgraphs.

These features are useful if you are solving BVPs with coefficients that vary along the boundary, or if you want to use strings on a domain with corners (my use case). 

All of these features are tested by chunkgraphrcipDataImpedanceTest, which solves an interior Helmholtz impedance problem with variable coefficients on the boundary using a somewhat silly version of the single layer potential. This uses multiple data rows and checks if both source and target data are properly interpolated during RCIP.