### PR TITLE
add rcip_identity to chunkermat

### DIFF
--- a/chunkie/chunkermat.m
+++ b/chunkie/chunkermat.m
@@ -76,6 +76,10 @@ function [sysmat,varargout] = chunkermat(chnkobj,kern,opts,ilist)
 %           opts.rcip_adaptive_correction = (false) flag for whether to use
 %                    adaptive quadrature for near touching panels on
 %                    different chunkers within rcip
+%           opts.rcip_identity = (1) scalar or vector of length nedges.
+%                    RCIP will assume that the total system is
+%                    rcip_identity*I + chunkermat. Passing a vector allows
+%                    a different strength on each edge. Cannot be zero.
 %           opts.eps = (1e-14) tolerance for adaptive quadrature
 %  ilist - cell array of integer arrays ([]), list of panel interactions that 
 %          should be ignored when constructing matrix entries or quadrature
@@ -146,6 +150,7 @@ nsub = 40;
 rcip_savedepth = 10;
 adaptive_correction = false;
 rcip_adaptive_correction = false;
+rcip_identity = 1;
 sing = 'log';
 
 % get opts from struct if available
@@ -181,6 +186,18 @@ if(isfield(opts,'rcip_ignore'))
         fprintf('in chunkermat: provided list of vertices to ignore in RCIP\n')
         fprintf('while RCIP is not enabled.\n')
     end
+end
+if(isfield(opts,'rcip_identity'))
+    rcip_identity = opts.rcip_identity;
+end
+
+if icgrph
+    % check the length of the diagonal scalings
+    nchunkers = length(chnkobj.echnks);
+    assert(isscalar(rcip_identity) || length(rcip_identity)==nchunkers, ...
+        'rcip_identity must be a scalar or a vector of length nchunkers');
+    assert(all(rcip_identity(:)~=0),'rcip_identity must be nonzero');
+    rcip_identity = rcip_identity(:).*ones(nchunkers,1);
 end
 
 if(isfield(opts,'nsub_or_tol'))
@@ -492,8 +509,19 @@ if(icgrph && isrcip)
     [~,nv] = size(chnkobj.verts);
     ngl = chnkrs(1).k;
 
+    % rescale kernels so that we build rcip for the matrix I + kernrcip.
+    kernrcip = kern;
+    if isscalar(kernrcip)
+        kernrcip = repmat(kernrcip,nchunkers,nchunkers);
+    end
+    for i=1:nchunkers
+        for j=1:nchunkers
+            kernrcip(i,j) = kernrcip(i,j).*(1/rcip_identity(i));
+        end
+    end
+
     rcipsav = cell(nv,1);
-    
+
     for ivert=setdiff(1:nv,rcip_ignore)
         clist = chnkobj.vstruc{ivert}{1};
         isstart = chnkobj.vstruc{ivert}{2};
@@ -522,6 +550,7 @@ if(icgrph && isrcip)
         end
         starind = zeros(1,2*ngl*ndim*nedge);
         corinds = cell(nedge,1);
+        diagstar = zeros(2*ngl*ndim*nedge,1);
         for i=1:nedge
             i1 = (i-1)*2*ngl*ndim+1;
             i2 = i*2*ngl*ndim;
@@ -532,6 +561,8 @@ if(icgrph && isrcip)
                 starind(i1:i2) = irowlocs(clist(i)+1)-fliplr(0:2*ngl*ndim-1)-1;
                 corinds{i} = (npt_all(clist(i))-2*ngl + 1):npt_all(clist(i));
             end
+            % identity scaling for rows of edge i in the rcip block
+            diagstar(i1:i2) = rcip_identity(clist(i));
         end
         
         [Pbc,PWbc,starL,circL,starS,circS,ilist,starL1,circL1] = ...
@@ -543,13 +574,15 @@ if(icgrph && isrcip)
         optsrcip.adaptive_correction = rcip_adaptive_correction;
 
 
-        [R,rcipsav{ivert}] = chnk.rcip.Rcompchunk(chnkrs,iedgechunks,kern,ndim,chnkobj.verts(:,ivert), ...
-            Pbc,PWbc,nsub,starL,circL,starS,circS,ilist,starL1,circL1,... 
+        [R,rcipsav{ivert}] = chnk.rcip.Rcompchunk(chnkrs,iedgechunks,kernrcip,ndim,chnkobj.verts(:,ivert), ...
+            Pbc,PWbc,nsub,starL,circL,starS,circS,ilist,starL1,circL1,...
             sbclmat,sbcrmat,lvmat,rvmat,u,optsrcip);
 
         rcipsav{ivert}.starind = starind;
 
-        sysmat_tmp = inv(R) - eye(2*ngl*nedge*ndim);
+        % R is built for I + kern/rcip_identity, now rescale to recover the
+        % correction for rcip_identity*I + kern
+        sysmat_tmp = diagstar.*(inv(R) - eye(2*ngl*nedge*ndim));
         if (~nonsmoothonly)
             
             sysmat(starind,starind) = sysmat_tmp;

--- a/devtools/test/chunkgrphrcip_identityTest.m
+++ b/devtools/test/chunkgrphrcip_identityTest.m
@@ -1,0 +1,231 @@
+% silence the near-singular warnings that occur in hypersingular corners
+ws = warning('off','MATLAB:nearlySingularMatrix');
+
+chunkgrphrcip_identityTest0();
+chunkgrphrcip_identityTest1();
+chunkgrphrcip_identityTest2();
+
+% restore the previous warning state
+warning(ws);
+
+
+function chunkgrphrcip_identityTest0()
+% constant rcip_identity c on a pentagon, checked against c times the
+% default assembly
+
+verts = exp(1i*2*pi*(0:4)/5);
+verts = [real(verts);imag(verts)];
+
+edge2verts = [-1, 1, 0, 0, 0; ...
+               0,-1, 1, 0, 0; ...
+               0, 0,-1, 1, 0; ...
+               0, 0, 0,-1, 1; ...
+               1, 0, 0, 0,-1];
+edge2verts = sparse(edge2verts);
+amp = 0.5;
+frq = 6;
+fchnks    = {};
+for icurve = 1:size(edge2verts,1)
+    fchnks{icurve} = @(t) sinearc(t,amp,frq);
+end
+
+prefs      = [];
+[cgrph] = chunkgraph(verts,edge2verts,fchnks,prefs);
+
+
+zk = 1.0;
+fkern = @(s,t) -2*chnk.helm2d.kern(zk,s,t,'d');
+
+c = 2.3;
+
+opts = [];
+opts.nonsmoothonly = false;
+opts.rcip = true;
+
+% default system I + chunkermat
+opts.rcip_identity = 1;
+[sysmat1] = chunkermat(cgrph,fkern,opts);
+sys1 = eye(size(sysmat1,2)) + sysmat1;
+
+% scaled system c*I + c*chunkermat = c*(I + chunkermat)
+opts.rcip_identity = c;
+fkernc = @(s,t) c*fkern(s,t);
+[sysmatc] = chunkermat(cgrph,fkernc,opts);
+sysc = c*eye(size(sysmatc,2)) + sysmatc;
+
+err = norm(sysc-c*sys1)/norm(c*sys1);
+fprintf('constant rcip_identity matrix discrepancy %5.2e\n',err);
+assert(err < 1e-12);
+
+end
+
+
+function chunkgrphrcip_identityTest1()
+% Per-edge rcip_identity on a two edge lens with mixed Dirichlet and Neumann.
+% The edges share both corners, so a different scaling meets on each side of
+% each corner. Checked against the default assembly with scaled kernels.
+
+% two arcs between (-1,0) and (1,0), forming a closed lens
+verts = [-1 1; 0 0];
+edgesendverts = [1 1; 2 2];
+fchnks = cell(1,2);
+fchnks{1} = @(t) lensarc(t,0.5);  % bows up
+fchnks{2} = @(t) lensarc(t,-0.5); % bows down
+
+cparams = [];
+cparams.nover = 2;
+[cgrph] = chunkgraph(verts,edgesendverts,fchnks,cparams);
+
+zk = 30;
+
+edir = 1; % Dirichlet edge
+eneu = 2; % Neumann edge
+
+% scale so the diagonal is identity (required for rcip)
+kerns(length([edir,eneu]),length([edir,eneu])) = kernel();
+kerns(edir,edir) = -2*kernel('helm', 'd', zk);
+kerns(eneu,edir) = -2*kernel('helm', 'dp', zk);
+
+kerns(edir,eneu) = 2*kernel('helm', 's', zk);
+kerns(eneu,eneu) = 2*kernel('helm', 'sp', zk);
+
+nedges = length(cgrph.echnks);
+
+rid = 1 + 0.5*(1:nedges).'; % different strength per edge
+
+opts = [];
+opts.rcip_identity = rid;
+[sysmatv] = chunkermat(cgrph,kerns,opts);
+
+% diagonal identity from the per-edge scalings
+dval = zeros(cgrph.npt,1);
+for ie = 1:nedges
+    inds = cgrph.edgeinds(ie);
+    dval(inds) = rid(ie);
+end
+sysv = diag(dval) + sysmatv;
+
+% scale rows of edge ie by 1/rid(ie), assemble, then rescale by rid(ie)
+kernscal = kerns;
+for ie = 1:nedges
+    for je = 1:nedges
+        kernscal(ie,je) = kernscal(ie,je).*(1/rid(ie));
+    end
+end
+[sysmat1] = chunkermat(cgrph,kernscal);
+sys1 = eye(size(sysmat1,2)) + sysmat1;
+sys1 = diag(dval)*sys1;
+
+err = norm(sysv-sys1)/norm(sys1);
+fprintf('per-edge rcip_identity matrix discrepancy %5.2e\n',err);
+assert(err < 1e-12);
+
+end
+
+
+function chunkgrphrcip_identityTest2()
+% The same lens as test1 but with opdims > 1. Checks the matrix and that
+% rcipsav postprocessing matches the default
+
+
+% two arcs between (-1,0) and (1,0), forming a closed lens
+verts = [-1 1; 0 0];
+edgesendverts = [1 1; 2 2];
+fchnks = cell(1,2);
+fchnks{1} = @(t) lensarc(t,0.5);  % bows up
+fchnks{2} = @(t) lensarc(t,-0.5); % bows down
+
+cparams = [];
+cparams.nover = 2;
+[cgrph] = chunkgraph(verts,edgesendverts,fchnks,cparams);
+
+zk = 30;
+nedges = length(cgrph.echnks);
+
+% opdims 2 blocks, interleaved from scalar helmholtz kernels
+sk = kernel('helm','s',zk);
+dk = kernel('helm','d',zk);
+spk = kernel('helm','sprime',zk);
+dpk = kernel('helm','dprime',zk);
+kblock = kernel([sk dk; spk dpk]);
+
+rid = 1 + 0.5*(1:nedges).'; % different strength per edge
+
+% scaled system, save full recursion for postprocessing
+opts = [];
+opts.rcip_identity = rid;
+opts.rcip_savedepth = Inf;
+[sysmatv,~,rcipsavv] = chunkermat(cgrph,kblock,opts);
+
+% diagonal identity, ndim rows per point on each edge
+ndim = kblock.opdims(1);
+dval = [];
+for ie = 1:nedges
+    nrowe = cgrph.echnks(ie).npt*ndim;
+    dval = [dval; rid(ie)*ones(nrowe,1)];
+end
+sysv = diag(dval) + sysmatv;
+
+% scale rows of edge ie by 1/rid(ie), assemble, then rescale by rid(ie)
+kernscal(nedges,nedges) = kernel();
+for ie = 1:nedges
+    for je = 1:nedges
+        kernscal(ie,je) = kblock.*(1/rid(ie));
+    end
+end
+opts1 = [];
+opts1.rcip_savedepth = Inf;
+[sysmat1,~,rcipsav1] = chunkermat(cgrph,kernscal,opts1);
+sysscal = eye(size(sysmat1,2)) + sysmat1;
+sys1 = diag(dval)*sysscal;
+
+err = norm(sysv-sys1)/norm(sys1);
+fprintf('per-edge opdims rcip_identity matrix discrepancy %5.2e\n',err);
+assert(err < 1e-12);
+
+% density is invariant: (D+K)x = b <=> (I+Dinv K)x = Dinv b
+rhs = randn(size(sysv,1),1);
+solv = sysv\rhs;
+sol1 = sysscal\(diag(1./dval)*rhs);
+assert(norm(solv-sol1)/norm(sol1) < 1e-10);
+
+% postprocessing reconstructs the same fine density from either rcipsav
+ndepth = 20;
+for ivert = 1:length(rcipsavv)
+    starind = rcipsavv{ivert}.starind;
+    interpv = cell2mat(chnk.rcip.rhohatInterp(solv(starind),rcipsavv{ivert},ndepth));
+    interp1 = cell2mat(chnk.rcip.rhohatInterp(sol1(starind),rcipsav1{ivert},ndepth));
+    fprintf('postprocessing density discrepancy %5.2e\n', ...
+        norm(interpv-interp1)/norm(interp1));
+    assert(norm(interpv-interp1)/norm(interp1) < 1e-10);
+end
+
+end
+
+
+function [r,d,d2] = sinearc(t,amp,frq)
+xs = t;
+ys = amp*sin(frq*t);
+xp = ones(size(t));
+yp = amp*frq*cos(frq*t);
+xpp = zeros(size(t));
+ypp = -frq*frq*amp*sin(t);
+
+r = [(xs(:)).'; (ys(:)).'];
+d = [(xp(:)).'; (yp(:)).'];
+d2 = [(xpp(:)).'; (ypp(:)).'];
+end
+
+function [r,d,d2] = lensarc(t,amp)
+% arc from (-1,0) at t=0 to (1,0) at t=1, bowing to height amp at t=1/2
+xs = -1 + 2*t;
+ys = amp*sin(pi*t);
+xp = 2*ones(size(t));
+yp = amp*pi*cos(pi*t);
+xpp = zeros(size(t));
+ypp = -amp*pi*pi*sin(pi*t);
+
+r = [(xs(:)).'; (ys(:)).'];
+d = [(xp(:)).'; (yp(:)).'];
+d2 = [(xpp(:)).'; (ypp(:)).'];
+end


### PR DESCRIPTION
Added support for RCIP with sys = c I + kern, rather than just I + kern. The c can be specified per edge (e.g. in mixed BVPs).

We do this by simply dividing the kernels for a given row by c, then rescaling the corner system matrix.

Currently c is passed to chunkermat using opts.rcip_identity, but there is probably a more user friendly way to do this.

It may also be worth considering supporting the case c = 0, i.e. First kind equations. That should be a small modification, but I might suggest waiting for a future pull request.