### PR TITLE
docs: add mip as the recommended way to install chunkIE

### DIFF
--- a/docs/getchunkie.rst
+++ b/docs/getchunkie.rst
@@ -4,7 +4,28 @@
 Get chunkIE
 ============
 
-Installation From Source 
+Install with mip (recommended)
+------------------------------
+
+The recommended way to install chunkIE is with `mip <https://mip.sh>`_, a package
+manager for MATLAB. After installing mip, run the following command in MATLAB:
+
+.. code:: matlab
+
+  >> mip install chunkie
+
+This will install chunkIE together with its dependencies using pre-built MEX
+binaries, so there is no need to compile anything yourself.
+
+Then load chunkIE onto your MATLAB path for the current session:
+
+.. code:: matlab
+
+  >> mip load chunkie
+  
+See `mip.sh/docs <https://mip.sh/docs>`_ for more information on using mip.
+
+Installation From Source
 ---------------------------
 
 Installation directly from source is not recommended for Windows


### PR DESCRIPTION
Adds an **Install with mip (recommended)** section to the top of the *Get chunkIE* documentation page, documenting installation via the [mip](https://mip.sh) package manager for MATLAB.

mip installs chunkIE together with its dependencies using pre-built MEX binaries, so users don't have to compile anything themselves — this sidesteps the fmm2d/mex compilation issues described further down the page. chunkie is registered in mip's core channel, so `mip install chunkie` works out of the box.

The existing "Installation From Source", "Precompiled Windows Binaries", and "Troubleshooting" sections are unchanged and follow the new mip section.