### PR TITLE
Fix pquad d2 interpolation and return in chunkerkerneval

### DIFF
--- a/chunkie/+chnk/pquadwts.m
+++ b/chunkie/+chnk/pquadwts.m
@@ -1,4 +1,4 @@
-function varargout = pquadwts(r,d,n,d2,wts,j,rt,t,w,opts,intp_ab,intp,types,ifup)
+function [allmats,srcinfo] = pquadwts(r,d,n,d2,wts,j,rt,t,w,opts,intp_ab,intp,types,ifup)
 %CHNK.pquadwts product integration for interaction of kernel on chunk
 % at targets
 %
@@ -31,7 +31,8 @@ function varargout = pquadwts(r,d,n,d2,wts,j,rt,t,w,opts,intp_ab,intp,types,ifup
 %       corresponds to (log(z-w))^a (log(zc-wc))^b (z-w)^c (zc-wc)^d
 %
 % Output
-%   varargout - integration matrices for specified singularity types
+%   allmats - cell array of integration matrices for specified singularity types
+%   srcinfo - upsampled source panel with fields: r, d, d2, n
 
 if nargin < 14, ifup = false; end
 
@@ -45,6 +46,11 @@ sp = abs(d_i); tang = d_i./sp;                    % speed, tangent
 n_i = -1i*tang;                                   % normal
 cur = -real(conj(d2_i).*n_i)./sp.^2;              % curvature
 wxp_i = w.*d_i;                                   % complex speed weights (Helsing's wzp)
+srcinfo = [];
+srcinfo.r  = [real(r_i)  imag(r_i)]';
+srcinfo.d  = [real(d_i)  imag(d_i)]';
+srcinfo.d2 = [real(d2_i) imag(d2_i)]';
+srcinfo.n  = [real(n_i)  imag(n_i)]';
 
 % determine number of matrices needed
 nout = 0;
@@ -80,19 +86,19 @@ else
     end
 end
 
-varargout = cell(size(types));
+allmats = cell(size(types));
 for j = 1:length(types)
     type0 = types{j};
     if (all(type0 == [0 0 0 0]))
-        varargout{j} = ones(size(rt,2),numel(wts_i)).*wts_i;
+        allmats{j} = ones(size(rt,2),numel(wts_i)).*wts_i;
     elseif (all(type0 == [1 0 0 0]))
-        varargout{j} = Ac{1};
+        allmats{j} = Ac{1};
     elseif (all(type0 == [0 0 -1 0]))
-        varargout{j} = Ac{2};
+        allmats{j} = Ac{2};
     elseif (all(type0 == [0 0 -2 0]))
-        varargout{j} = Ac{3};
+        allmats{j} = Ac{3};
     elseif (all(type0 == [0 0 -3 0]))
-        varargout{j} = Ac{4};
+        allmats{j} = Ac{4};
     else
         error("Split panel quad type [%s] not available",...
             join(string(type0)," "));

--- a/chunkie/chunkerkerneval.m
+++ b/chunkie/chunkerkerneval.m
@@ -309,7 +309,7 @@ if opts_use.forcepquad
     fints(irow0) = fints(irow0) + chunkerkerneval_pquad(chnkr0,kern0,opdims0,dens0, ...
         targinfo0,flag,opts_use);
 
-    return
+    continue
 end
 
 % smooth for sufficiently far, adaptive otherwise
@@ -345,6 +345,12 @@ function fints = chunkerkerneval_pquad(chnkr,kern,opdims,dens, ...
 
 if ~isa(kern,'kernel') || isempty(kern.splitinfo)
     error('Helsing-Ojala quad only available for kernel class objects with splitinfo defined');
+end
+
+scalar = 1;
+q = functions(kern.eval);
+if ~isempty(q.workspace) && isfield(q.workspace{1},'g')
+    scalar = q.workspace{1}.g;
 end
 
 % target
@@ -402,7 +408,7 @@ for j=1:size(chnkr.r,3)
         allmatsf = cell(size(kern.splitinfo.type));
         [allmatsf,srcinfof] = chnk.pquadwts(r,d,n,d2,wts,j,targs(:,ji),t,w, ...
             opts,intp_ab,intp,kern.splitinfo.type,true);
-        
+
         funsf = kern.splitinfo.functions(srcinfof,targinfoji);
         for l = 1:length(allmatsf)
             switch kern.splitinfo.action{l}
@@ -420,6 +426,9 @@ for j=1:size(chnkr.r,3)
         end
     end
 end
+
+fints = scalar*fints;
+
 end
 
 

--- a/chunkie/chunkerkerneval.m
+++ b/chunkie/chunkerkerneval.m
@@ -400,20 +400,9 @@ for j=1:size(chnkr.r,3)
 
         % Helsing-Ojala (interior/exterior?)
         allmatsf = cell(size(kern.splitinfo.type));
-        [allmatsf{:}] = chnk.pquadwts(r,d,n,d2,wts,j,targs(:,ji),t,w, ...
+        [allmatsf,srcinfof] = chnk.pquadwts(r,d,n,d2,wts,j,targs(:,ji),t,w, ...
             opts,intp_ab,intp,kern.splitinfo.type,true);
-
-        r_i = intp*(r(1,:,j)'+1i*r(2,:,j)'); 
-        d_i = (intp*(d(1,:,j)'+1i*d(2,:,j)'));
-        d2_i = (intp*(d(1,:,j)'+1i*d(2,:,j)'));
-        sp = abs(d_i); tang = d_i./sp; 
-        n_i = -1i*tang; 
-        srcinfof = [];
-        srcinfof.r  = [real(r_i)  imag(r_i)]';
-        srcinfof.d  = [real(d_i)  imag(d_i)]';
-        srcinfof.d2 = [real(d2_i) imag(d2_i)]';
-        srcinfof.n  = [real(n_i)  imag(n_i)]';
-
+        
         funsf = kern.splitinfo.functions(srcinfof,targinfoji);
         for l = 1:length(allmatsf)
             switch kern.splitinfo.action{l}

--- a/chunkie/chunkerkernevalmat.m
+++ b/chunkie/chunkerkernevalmat.m
@@ -588,10 +588,14 @@ end
 function mat = chunkerkernevalmat_pquad(chnkr,kern,opdims, ...
     targinfo,flag,opts)
 
-if isa(kern,'kernel')
-    kerneval = kern.eval;
-else
-    kerneval = kern;
+if ~isa(kern,'kernel') || isempty(kern.splitinfo)
+    error('Helsing-Ojala quad only available for kernel class objects with splitinfo defined');
+end
+
+scalar = 1;
+q = functions(kern.eval);
+if ~isempty(q.workspace) && isfield(q.workspace{1},'g')
+    scalar = q.workspace{1}.g;
 end
 
 k = chnkr.k;
@@ -654,6 +658,17 @@ else
 
         targinfoji = [];
         targinfoji.r = targinfo.r(:,ji);
+        if isfield(targinfo, 'd')
+            targinfoji.d = targinfo.d(:,ji);
+        end
+
+        if isfield(targinfo, 'd2')
+            targinfoji.d2 = targinfo.d2(:,ji);
+        end
+
+        if isfield(targinfo, 'n')
+            targinfoji.n = targinfo.n(:,ji);
+        end        
 
         srcinfo = [];
         srcinfo.r = r(:,:,i);
@@ -719,7 +734,7 @@ else
             mat0xsplitfun = mat0opdim.*funsf{l};
             mat1f = mat1f + mat0xsplitfun;
         end
-        mat1 = mat1f*kron(intp,eye(opdims(:).'));
+        mat1 = mat1f*kron(intp,eye(opdims(2)));
 
         else
             mat1 = [];
@@ -758,14 +773,14 @@ else
                 mat0xsplitfun = mat0opdim.*funsf{l};
                 mat2f = mat2f + mat0xsplitfun;
             end
-            mat2 = mat2f*kron(intp,eye(opdims(:).'));
+            mat2 = mat2f*kron(intp,eye(opdims(2)));
         else
             mat2 = [];
         end
 
-        mat3 = zeros(size(targinfoji.r,2),k);
-        mat3(iiin,:) = mat1;
-        mat3(iout,:) = mat2;
+        mat3 = zeros(opdims(1)*size(targinfoji.r,2),opdims(2)*k);
+        mat3(repelem(iiin,opdims(1)),:) = mat1;
+        mat3(repelem(iout,opdims(1)),:) = mat2;
 
 
         js1 = jmat:jmatend;
@@ -791,5 +806,5 @@ end
 if dclosest < 1e-10
     warning('Unable to estimate pquad side. Provide opts.side to ensure accuracy.')
 end
-
+mat = scalar*mat;
 end

--- a/chunkie/chunkerkernevalmat.m
+++ b/chunkie/chunkerkernevalmat.m
@@ -701,19 +701,8 @@ else
 
         % Helsing-Ojala (interior/exterior?)
         allmatsf = cell(size(kern.splitinfo.type));
-        [allmatsf{:}] = chnk.pquadwts(r,d,n,d2,wts,i,targinfouse.r,t,w, ...
+        [allmatsf,srcinfof] = chnk.pquadwts(r,d,n,d2,wts,i,targinfouse.r,t,w, ...
             optsuse,intp_ab,intp,kern.splitinfo.type,true);
-
-        r_i = intp*(r(1,:,i)'+1i*r(2,:,i)'); 
-        d_i = (intp*(d(1,:,i)'+1i*d(2,:,i)'));
-        d2_i = (intp*(d(1,:,i)'+1i*d(2,:,i)'));
-        sp = abs(d_i); tang = d_i./sp; 
-        n_i = -1i*tang; 
-        srcinfof = [];
-        srcinfof.r  = [real(r_i)  imag(r_i)]';
-        srcinfof.d  = [real(d_i)  imag(d_i)]';
-        srcinfof.d2 = [real(d2_i) imag(d2_i)]';
-        srcinfof.n  = [real(n_i)  imag(n_i)]';
 
         mat1f = zeros(opdims(1)*size(targinfouse.r,2),opdims(2)*2*k);
         funsf = kern.splitinfo.functions(srcinfof,targinfouse);
@@ -751,19 +740,8 @@ else
             optsuse.side = 'e';
             % Helsing-Ojala (interior/exterior?)
             allmatsf = cell(size(kern.splitinfo.type));
-            [allmatsf{:}] = chnk.pquadwts(r,d,n,d2,wts,i,targinfouse.r,t,w, ...
+            [allmatsf,srcinfof] = chnk.pquadwts(r,d,n,d2,wts,i,targinfouse.r,t,w, ...
                 optsuse,intp_ab,intp,kern.splitinfo.type,true);
-    
-            r_i = intp*(r(1,:,i)'+1i*r(2,:,i)'); 
-            d_i = (intp*(d(1,:,i)'+1i*d(2,:,i)'));
-            d2_i = (intp*(d(1,:,i)'+1i*d(2,:,i)'));
-            sp = abs(d_i); tang = d_i./sp; 
-            n_i = -1i*tang; 
-            srcinfof = [];
-            srcinfof.r  = [real(r_i)  imag(r_i)]';
-            srcinfof.d  = [real(d_i)  imag(d_i)]';
-            srcinfof.d2 = [real(d2_i) imag(d2_i)]';
-            srcinfof.n  = [real(n_i)  imag(n_i)]';
     
             mat2f = zeros(opdims(1)*size(targinfouse.r,2),opdims(2)*2*k);
             funsf = kern.splitinfo.functions(srcinfof,targinfouse);

--- a/devtools/test/chunkermat_stok2dTest.m
+++ b/devtools/test/chunkermat_stok2dTest.m
@@ -103,7 +103,10 @@ assert(norm(err) < 1e-10);
 opts.forcepquad=true;
 opts.side = 'i';
 Ssol_pquad = chunkerkerneval(chnkr,fkerns,sol,targets,opts); 
+Ssys_pquad = chunkerkernevalmat(chnkr,fkerns,targets,opts);
 err = abs(Ssol - Ssol_pquad);
+assert(norm(err) < 1e-10);
+err = abs(Ssol - Ssys_pquad*sol);
 assert(norm(err) < 1e-10);
 opts.forcepquad=false;
 
@@ -114,7 +117,10 @@ Dsol = chunkerkerneval(chnkr,fkernd,sol,targets,opts);
 opts.forcepquad=true;
 opts.side = 'i';
 Dsol_pquad = chunkerkerneval(chnkr,fkernd,sol,targets,opts); 
+Dsys_pquad = chunkerkernevalmat(chnkr,fkernd,targets,opts);
 err = abs(Dsol - Dsol_pquad);
+assert(norm(err) < 1e-10);
+err = abs(Dsol - Dsys_pquad*sol);
 assert(norm(err) < 1e-10);
 opts.forcepquad=false;
 
@@ -125,7 +131,10 @@ Stracsol = chunkerkerneval(chnkr,fkernstrac,sol,targinfo,opts);
 opts.forcepquad=true;
 opts.side = 'i';
 Stracsol_pquad = chunkerkerneval(chnkr,fkernstrac,sol,targinfo,opts); 
+Stracsys_pquad = chunkerkernevalmat(chnkr,fkernstrac,targinfo,opts);
 err = abs(Stracsol - Stracsol_pquad);
+assert(norm(err) < 1e-10);
+err = abs(Stracsol - Stracsys_pquad*sol);
 assert(norm(err) < 1e-10);
 opts.forcepquad=false;
 
@@ -136,7 +145,10 @@ Dtracsol = chunkerkerneval(chnkr,fkerndtrac,sol,targinfo,opts);
 opts.forcepquad=true;
 opts.side = 'i';
 Dtracsol_pquad = chunkerkerneval(chnkr,fkerndtrac,sol,targinfo,opts); 
+Dtracsys_pquad = chunkerkernevalmat(chnkr,fkerndtrac,targinfo,opts);
 err = abs(Dtracsol - Dtracsol_pquad);
+assert(norm(err) < 1e-8);
+err = abs(Dtracsol - Dtracsys_pquad*sol);
 assert(norm(err) < 1e-8);
 opts.forcepquad=false;
 
@@ -147,7 +159,10 @@ Spressol = chunkerkerneval(chnkr,fkernspres,sol,targinfo,opts);
 opts.forcepquad=true;
 opts.side = 'i';
 Spressol_pquad = chunkerkerneval(chnkr,fkernspres,sol,targinfo,opts); 
+Spressys_pquad = chunkerkernevalmat(chnkr,fkernspres,targinfo,opts);
 err = abs(Spressol - Spressol_pquad);
+assert(norm(err) < 1e-10);
+err = abs(Spressol - Spressys_pquad*sol);
 assert(norm(err) < 1e-10);
 opts.forcepquad=false;
 
@@ -158,7 +173,10 @@ Dpressol = chunkerkerneval(chnkr,fkerndpres,sol,targinfo,opts);
 opts.forcepquad=true;
 opts.side = 'i';
 Dpressol_pquad = chunkerkerneval(chnkr,fkerndpres,sol,targinfo,opts); 
+Dpressys_pquad = chunkerkernevalmat(chnkr,fkerndpres,targinfo,opts);
 err = abs(Dpressol - Dpressol_pquad);
+assert(norm(err) < 1e-10);
+err = abs(Dpressol - Dpressys_pquad*sol);
 assert(norm(err) < 1e-10);
 opts.forcepquad=false;
 


### PR DESCRIPTION
This PR fixed the pquad issues reported in #196 and #197 .

- Updates `pquadwts` to pass upsampled second derivative `d2` to kernel-split evaluation.
- Replaces `return` with `continue` to allow all edges of a chunkgraph. `demo_mixed_bc.m`
- Update stokes slp and dlp, velocity, traction and pressure `chunkerkerneval` and `chunkerkernevalmat` test. `chunkermat_stok2dTest.m` 